### PR TITLE
fix: define min and max when creating array in test

### DIFF
--- a/src/defaults/inMemoryDataAdapter.test.ts
+++ b/src/defaults/inMemoryDataAdapter.test.ts
@@ -147,7 +147,10 @@ function createArrayOfIndempotencyResource(
     maxResource: number = faker.random.number(999)
 ): IdempotencyResource[] {
     const idempotencyResources: IdempotencyResource[] = [];
-    const resourceCount: number = faker.random.number(maxResource);
+    const resourceCount: number = faker.random.number({
+        min: 1,
+        max: maxResource,
+    });
     for (let i = 0; i < resourceCount; i++) {
         idempotencyResources.push(createFakeIdempotencyResource());
     }


### PR DESCRIPTION
Prevent tests to fail because creating an array of 0 resource when default minimum of faker is reached.