### PR TITLE
feat: added autobind-decorator lib to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/sinon": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
-    "autobind-decorator": "^2.4.0",
     "chai": "^4.2.0",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
@@ -57,7 +56,8 @@
   ],
   "dependencies": {
     "deep-equal": "^2.0.3",
-    "http-status-codes": "^1.4.0"
+    "http-status-codes": "^1.4.0",
+    "autobind-decorator": "^2.4.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Following this issue: #10 , autobind-decorator should be in dependencies.