### PR TITLE
feat: expire orphaned in-progress resources via processing timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,12 @@ jobs:
       - coverage-reporter/send_report:
           coverage-reports: "coverage/lcov.info"
           project-token: ${CODACY_PROJECT_TOKEN}
+  e2e:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run: npm run test:e2e
   package:
     <<: *defaults
     steps:
@@ -81,9 +87,18 @@ workflows:
               only: /^v\d+\.{1}\d+.{1}\d.*+/
             branches:
               only: /.*/
+      - e2e:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v\d+\.{1}\d+.{1}\d.*+/
+            branches:
+              only: /.*/
       - package:
           requires:
             - test
+            - e2e
           filters:
             tags:
               only: /^v\d+\.{1}\d+.{1}\d.*+/

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,5 +2,6 @@
 exclude_paths:
     - '**.md'
     - '**/*.test.ts'
+    - 'tests/**'
     - 'examples/**'
     - '**.json'

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn.lock
 
 # Test compilation
 .temp
+.temp-e2e/

--- a/.mocharc.e2e.yml
+++ b/.mocharc.e2e.yml
@@ -1,0 +1,8 @@
+# Mocha configuration — end-to-end suite (real HTTP server).
+recursive: true
+require:
+    - ts-node/register
+    - source-map-support/register
+spec: 'tests/e2e/**/*.e2e.test.ts'
+timeout: 10000
+exit: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `processingTimeout` option (milliseconds): lease mechanism that allows a retry to take over processing of an in-progress resource after the timeout elapses, preventing permanent `409` locks caused by orphaned requests (crash, OOM, rollout). Opt-in; disabled when absent or `<= 0`. Requires the data adapter to persist and return `IdempotencyResource.createdAt`. (issue #32)
 - `IdempotencyResource.createdAt` field (`Date | number`, optional): timestamp stamped unconditionally by the middleware at resource creation. Used by the `processingTimeout` lease mechanism; absent value degrades safely to the v2.0.0 behaviour.
+- End-to-end test suite (`npm run test:e2e`) exercising the middleware over a real HTTP server (Express + native `fetch`): replay/hit, `409` in-progress conflict, concurrent retries, `processingTimeout` takeover, zombie-write guard, phantom-key cleanup (`res.end` bypass), intent mismatch (`417`) and `reportError`. Factored as `runIdempotencySuite` for reuse across data adapters, runnable standalone via `npm run e2e:serve`, and wired as a dedicated CI job.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `processingTimeout` option (milliseconds): lease mechanism that allows a retry to take over processing of an in-progress resource after the timeout elapses, preventing permanent `409` locks caused by orphaned requests (crash, OOM, rollout). Opt-in; disabled when absent or `<= 0`. Requires the data adapter to persist and return `IdempotencyResource.createdAt`. (issue #32)
+- `IdempotencyResource.createdAt` field (`Date | number`, optional): timestamp stamped unconditionally by the middleware at resource creation. Used by the `processingTimeout` lease mechanism; absent value degrades safely to the v2.0.0 behaviour.
+
+### Fixed
+
+- Resources left in-progress when the response bypasses `res.send` (e.g. `res.end()`, streaming, `sendFile`) are now automatically deleted on the `finish` event, allowing the next retry to be reprocessed instead of receiving a permanent `409`.
+- `InMemoryDataAdapter.update` no longer creates a phantom `"-1"` property on the internal array when called with an unknown key; it is now a no-op, aligned with MongoDB `updateOne` semantics.
+
 ## [2.0.0] - 2025-11-05
 
 ### 🎉 Major Upgrade - All Dependencies Updated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ Librairie npm open source (`express-idempotency`, MIT) : middleware Express qui 
 | `npm run compile` | Build de distribution → `dist/` (`tsconfig.dist.json`, CommonJS, ES2020, `.d.ts` émis) |
 | `npm run lint` / `npm run lint:fix` | ESLint 9 (flat config `eslint.config.js`) |
 | `npm run prettier` / `npm run prettier:fix` | Prettier en mode check / write |
+| `npm run test:e2e` | Suite e2e sur vrai serveur HTTP (`.mocharc.e2e.yml` + `tsconfig.e2e.json`, specs `tests/e2e/**/*.e2e.test.ts`) |
+| `npm run test:all` | `npm test` (unitaire) puis `npm run test:e2e` |
+| `npm run e2e:serve` | Démarre le harness en standalone (port 8080, override `PORT`) pour debug manuel (curl/REST) |
 
 Hooks Husky : `pre-commit` est vide par design ; `pre-push` exécute `npm run prettier && npm run lint && npm test` — tout doit passer avant un push. `commit-msg` impose Conventional Commits (commitlint).
 
@@ -26,6 +29,15 @@ Hooks Husky : `pre-commit` est vide par design ; `pre-push` exécute `npm run pr
 ## Release
 
 CircleCI publie sur npm uniquement sur tag git : `vX.Y.Z` → publication normale, `vX.Y.Z-<suffixe>` → publication avec dist-tag `rc`. Les tests tournent sur toutes les branches ; la couverture (lcov) part vers Codacy. Branches : `master` (production) et `develop`.
+
+## Tests e2e
+
+Suite de bout en bout dans `tests/e2e/` (**hors `src/`** → exclue de la couverture lcov et du package `dist`). Vrai serveur HTTP (Express + `fetch` natif, port éphémère), pas de mocks. Requiert Node ≥ 18.2 ; `express` et `cross-env` sont en devDependencies.
+
+- `tests/e2e/harness/` — harness réutilisable : `buildApp(options?)` (app + routes instrumentées + error handler), `startServer(app)` (port 0 + mode standalone, draine les requêtes in-flight au close), `controls` (gates déterministes, compteurs d'exécution, traçage des `delete`), `runIdempotencySuite(makeApp)` rejouable sur n'importe quel data adapter.
+- `tests/e2e/inmemory.e2e.test.ts` — exécute la suite sur l'`InMemoryDataAdapter` par défaut.
+- **Contrat error-handler** : le middleware fait `res.status(409|417); next(err)` ; un error handler Express explicite (présent dans `buildApp`) est requis pour propager ces codes, sinon Express renvoie 500.
+- Lancé en CI par un job CircleCI dédié `e2e` ; `package` est gaté sur `test` + `e2e`. Le `pre-push` Husky ne lance PAS les e2e (CI-only).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ app.post(
         responseValidator,
         // Logic to detect misuse of the idempotency key
         intentValidator,
+        // Maximum processing time (ms) before an in-progress resource is
+        // considered orphaned and can be taken over by a retry.
+        // Disabled when absent or <= 0.
+        processingTimeout,
     })
 );
 ```
@@ -153,6 +157,30 @@ export class CustomIntentValidator implements IIdempotencyIntentValidator {
     return req.url === idempotencyRequest.url;
   }
 ```
+
+#### Processing timeout
+
+By default, if a request starts processing but never completes (crash, OOM, rollout, or a response sent via `res.end()` / streaming / `sendFile` that bypasses `res.send`), the in-progress resource remains locked and subsequent retries receive a permanent `409 Conflict` until the adapter's TTL expires.
+
+The `processingTimeout` option (in milliseconds) enables a lease mechanism: if a retry arrives after the timeout has elapsed since the resource was created, the middleware considers the original request orphaned and takes over processing.
+
+```javascript
+app.post(
+    '*',
+    idempotency({
+        dataAdapter,
+        // Allow a retry to take over after 30 seconds
+        processingTimeout: 30_000,
+    })
+);
+```
+
+**Requirements and caveats:**
+
+- The data adapter must persist and return the `createdAt` field of `IdempotencyResource`. Without it the feature is silently inert (safe degradation to the v2.0.0 behaviour).
+- Choose a value at least 2× the worst-case processing duration to avoid false takeovers.
+- Due to the check-then-act nature of the takeover, at-least-once delivery semantics apply when the timeout is reached. If two retries race at expiry, one will win and the other will fall back to a `409`.
+- When a response is sent via `res.end()`, streaming, or `sendFile` (bypassing `res.send`), the middleware cannot capture the body. It automatically deletes the resource so the next retry is reprocessed rather than permanently blocked.
 
 ## License
 
@@ -260,6 +288,10 @@ app.post(
         responseValidator,
         // Préciser la logique à appliquer pour s'assurer de la bonne utilisation de la clé d'idempotence.
         intentValidator,
+        // Durée maximale de traitement (ms) avant qu'une ressource en cours soit
+        // considérée orpheline et reprise par une nouvelle tentative.
+        // Désactivé si absent ou <= 0.
+        processingTimeout,
     })
 );
 ```
@@ -307,6 +339,30 @@ export class CustomIntentValidator implements IIdempotencyIntentValidator {
     return req.url === idempotencyRequest.url;
   }
 ```
+
+#### Délai de traitement
+
+Par défaut, si une requête démarre son traitement mais ne se termine jamais (crash, OOM, redéploiement, ou réponse envoyée via `res.end()` / streaming / `sendFile` sans passer par `res.send`), la ressource en cours reste verrouillée et les nouvelles tentatives reçoivent un `409 Conflict` permanent jusqu'à l'expiration du TTL de l'adapteur.
+
+L'option `processingTimeout` (en millisecondes) active un mécanisme de bail : si une nouvelle tentative arrive après l'écoulement du délai depuis la création de la ressource, le middleware considère la requête originale comme orpheline et reprend le traitement.
+
+```javascript
+app.post(
+    '*',
+    idempotency({
+        dataAdapter,
+        // Permettre à une nouvelle tentative de reprendre après 30 secondes
+        processingTimeout: 30_000,
+    })
+);
+```
+
+**Prérequis et mises en garde :**
+
+- L'adapteur de données doit persister et retourner le champ `createdAt` de `IdempotencyResource`. Sans cela, la fonctionnalité est silencieusement inerte (dégradation propre vers le comportement v2.0.0).
+- Choisir une valeur d'au moins 2× la durée de traitement maximale pour éviter les reprises prématurées.
+- En raison de la nature « vérifier puis agir » de la reprise, une sémantique de livraison « au moins une fois » s'applique lorsque le délai est atteint. Si deux tentatives entrent en concurrence à l'expiration, l'une gagnera et l'autre recevra un `409`.
+- Lorsqu'une réponse est envoyée via `res.end()`, le streaming ou `sendFile` (sans passer par `res.send`), le middleware ne peut pas capturer le corps. Il supprime automatiquement la ressource afin que la prochaine tentative soit retraitée plutôt que bloquée de façon permanente.
 
 ## Contribuer
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,42 @@ app.post(
 - Due to the check-then-act nature of the takeover, at-least-once delivery semantics apply when the timeout is reached. If two retries race at expiry, one will win and the other will fall back to a `409`.
 - When a response is sent via `res.end()`, streaming, or `sendFile` (bypassing `res.send`), the middleware cannot capture the body. It automatically deletes the resource so the next retry is reprocessed rather than permanently blocked.
 
+## Testing
+
+This library has two test layers, both run in CI on every branch:
+
+- **Unit tests** — `npm test` (mock-based, fast; coverage reported to Codacy via lcov).
+- **End-to-end tests** — `npm run test:e2e` exercises the full middleware over a **real HTTP server** (Express + native `fetch`): replay/hit, `409` in-progress conflict, concurrent retries, `processingTimeout` takeover, zombie-write guard, phantom-key cleanup (`res.end` bypass), intent mismatch (`417`) and `reportError`.
+
+`npm run test:all` runs both layers. The e2e suite requires **Node >= 18.2** (it relies on `server.closeAllConnections`).
+
+### Manual probing
+
+A standalone harness server is available for manual exploration with curl or a REST client:
+
+```bash
+npm run e2e:serve   # http://localhost:8080 (override with the PORT env var)
+
+# Same key replays the first response; a different key is processed fresh:
+curl -H 'Idempotency-Key: demo-1' http://localhost:8080/resource
+curl -H 'Idempotency-Key: demo-1' http://localhost:8080/resource
+```
+
+> **Error-handler contract:** the middleware signals conflicts and misuse by setting the status (`409` / `417`) and calling `next(err)`. Your app must register an Express error handler that honours the already-set `res.statusCode`, otherwise Express emits a generic `500`. See `tests/e2e/harness/buildApp.ts` for a reference handler.
+
+### Reusing the suite for custom adapters
+
+The behavioural suite is factored as `runIdempotencySuite(makeApp)` (`tests/e2e/harness/scenarios.ts`), so a custom data adapter can replay the exact same guarantees:
+
+```typescript
+import { buildApp } from './harness/buildApp';
+import { runIdempotencySuite } from './harness/scenarios';
+
+describe('MyAdapter over real HTTP', () => {
+    runIdempotencySuite((options) => buildApp({ ...options, dataAdapter: new MyAdapter() }));
+});
+```
+
 ## License
 
 The source code of this project is distributed under the [MIT License](LICENSE).
@@ -363,6 +399,42 @@ app.post(
 - Choisir une valeur d'au moins 2× la durée de traitement maximale pour éviter les reprises prématurées.
 - En raison de la nature « vérifier puis agir » de la reprise, une sémantique de livraison « au moins une fois » s'applique lorsque le délai est atteint. Si deux tentatives entrent en concurrence à l'expiration, l'une gagnera et l'autre recevra un `409`.
 - Lorsqu'une réponse est envoyée via `res.end()`, le streaming ou `sendFile` (sans passer par `res.send`), le middleware ne peut pas capturer le corps. Il supprime automatiquement la ressource afin que la prochaine tentative soit retraitée plutôt que bloquée de façon permanente.
+
+## Tests
+
+La librairie comporte deux niveaux de tests, tous deux exécutés en CI sur chaque branche :
+
+- **Tests unitaires** — `npm test` (basés sur des mocks, rapides ; couverture envoyée à Codacy via lcov).
+- **Tests de bout en bout** — `npm run test:e2e` exerce l'ensemble du middleware sur un **vrai serveur HTTP** (Express + `fetch` natif) : rejeu/hit, conflit `409` en cours de traitement, tentatives concurrentes, reprise par `processingTimeout`, garde anti-écriture « zombie », nettoyage des clés fantômes (contournement de `res.send` via `res.end()`), intention divergente (`417`) et `reportError`.
+
+`npm run test:all` lance les deux niveaux. La suite e2e requiert **Node >= 18.2** (elle s'appuie sur `server.closeAllConnections`).
+
+### Exploration manuelle
+
+Un serveur de test autonome permet une exploration manuelle (curl ou client REST) :
+
+```bash
+npm run e2e:serve   # http://localhost:8080 (modifiable via la variable d'env PORT)
+
+# Une même clé rejoue la première réponse ; une clé différente est traitée à neuf :
+curl -H 'Idempotency-Key: demo-1' http://localhost:8080/resource
+curl -H 'Idempotency-Key: demo-1' http://localhost:8080/resource
+```
+
+> **Contrat du gestionnaire d'erreurs :** le middleware signale les conflits et les mésusages en positionnant le statut (`409` / `417`) puis en appelant `next(err)`. Votre application doit enregistrer un gestionnaire d'erreurs Express qui respecte le `res.statusCode` déjà positionné, sinon Express renvoie un `500` générique. Voir `tests/e2e/harness/buildApp.ts` pour un gestionnaire de référence.
+
+### Réutiliser la suite pour des adapteurs personnalisés
+
+La suite comportementale est factorisée sous la forme `runIdempotencySuite(makeApp)` (`tests/e2e/harness/scenarios.ts`), de sorte qu'un adapteur de données personnalisé peut rejouer exactement les mêmes garanties :
+
+```typescript
+import { buildApp } from './harness/buildApp';
+import { runIdempotencySuite } from './harness/scenarios';
+
+describe('MonAdapteur sur un vrai serveur HTTP', () => {
+    runIdempotencySuite((options) => buildApp({ ...options, dataAdapter: new MonAdapteur() }));
+});
+```
 
 ## Contribuer
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,11 @@ module.exports = [
         plugins: {
             '@typescript-eslint': tseslint,
         },
+        linterOptions: {
+            // Inline disable directives may target rules enforced only by
+            // external analyzers (e.g. Codacy) that are not enabled locally.
+            reportUnusedDisableDirectives: 'off',
+        },
         rules: {
             ...tseslint.configs.recommended.rules,
             '@typescript-eslint/no-explicit-any': 0,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ const path = require('path');
 module.exports = [
     // Global ignores
     {
-        ignores: ['**/*.test.ts', 'dist/**', 'node_modules/**'],
+        ignores: ['**/*.test.ts', 'dist/**', 'node_modules/**', 'tests/**'],
     },
     // Base ESLint recommended rules
     eslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,16 @@
         "@types/express": "^5.0.5",
         "@types/express-serve-static-core": "^5.1.0",
         "@types/mocha": "^10.0.10",
+        "@types/node": "^25.9.3",
         "@types/serve-static": "^2.2.0",
         "@types/sinon": "^21.0.1",
         "@typescript-eslint/eslint-plugin": "^8.46.3",
         "@typescript-eslint/parser": "^8.46.3",
         "chai": "^6.2.0",
+        "cross-env": "^10.1.0",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
+        "express": "^5.2.1",
         "husky": "^9.1.7",
         "mocha": "^11.7.5",
         "node-mocks-http": "^1.17.2",
@@ -593,6 +596,13 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -1335,14 +1345,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qs": {
@@ -1850,6 +1860,101 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -1921,6 +2026,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/caching-transform": {
       "version": "4.0.0",
@@ -2227,6 +2342,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -2278,6 +2403,26 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
@@ -2331,6 +2476,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2531,6 +2694,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.245",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.245.tgz",
@@ -2544,6 +2714,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -2631,6 +2811,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3048,6 +3235,201 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3152,6 +3534,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-cache-dir": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
@@ -3249,6 +3653,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
@@ -3581,6 +3995,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
@@ -3601,6 +4046,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -3671,6 +4133,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -3693,6 +4162,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arguments": {
@@ -3894,6 +4373,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -5300,6 +5786,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5482,6 +5991,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5629,6 +6149,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5637,6 +6171,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -5668,6 +6218,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -5869,6 +6435,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5931,6 +6524,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5944,6 +6544,70 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
@@ -5952,6 +6616,26 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -5992,6 +6676,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6195,6 +6886,16 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6494,6 +7195,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6634,9 +7345,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6651,6 +7362,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6700,6 +7421,16 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6896,6 +7627,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "lint:fix": "./node_modules/.bin/eslint ./src --ext .ts,.tsx --fix",
     "prettier": "./node_modules/.bin/prettier --check ./src",
     "prettier:fix": "./node_modules/.bin/prettier --write ./src",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:e2e": "cross-env TS_NODE_PROJECT=tsconfig.e2e.json mocha --config .mocharc.e2e.yml",
+    "test:all": "npm test && npm run test:e2e",
+    "e2e:serve": "cross-env TS_NODE_PROJECT=tsconfig.e2e.json ts-node tests/e2e/harness/server.ts"
   },
   "repository": {
     "type": "git",
@@ -40,13 +43,16 @@
     "@types/express": "^5.0.5",
     "@types/express-serve-static-core": "^5.1.0",
     "@types/mocha": "^10.0.10",
+    "@types/node": "^25.9.3",
     "@types/serve-static": "^2.2.0",
     "@types/sinon": "^21.0.1",
     "@typescript-eslint/eslint-plugin": "^8.46.3",
     "@typescript-eslint/parser": "^8.46.3",
     "chai": "^6.2.0",
+    "cross-env": "^10.1.0",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
+    "express": "^5.2.1",
     "husky": "^9.1.7",
     "mocha": "^11.7.5",
     "node-mocks-http": "^1.17.2",

--- a/src/defaults/inMemoryDataAdapter.test.ts
+++ b/src/defaults/inMemoryDataAdapter.test.ts
@@ -87,6 +87,30 @@ describe('In memory data adapter', () => {
         assert.deepEqual(idempotencyFoundAgain.response, idempotencyResponse);
     });
 
+    it('update is a no-op when key does not exist', async () => {
+        const existing = createFakeIdempotencyResource();
+        await dataAdapter.create(existing);
+
+        const ghost = createFakeIdempotencyResource(); // unknown key, never created
+        await dataAdapter.update(ghost);
+
+        // The phantom key must not appear in the adapter
+        const found = await dataAdapter.findByIdempotencyKey(
+            ghost.idempotencyKey
+        );
+        assert.isNull(found);
+
+        // The existing resource must be untouched
+        const existingFound = await dataAdapter.findByIdempotencyKey(
+            existing.idempotencyKey
+        );
+        assert.ok(existingFound);
+
+        // No "-1" phantom property must have been created on the internal array
+        const adapter = dataAdapter as any;
+        assert.isUndefined(adapter.idempotencyResources['-1']);
+    });
+
     it('deletes resource', async () => {
         // Generate resources
         const idempotencyResources = createArrayOfIndempotencyResource(10);

--- a/src/defaults/inMemoryDataAdapter.ts
+++ b/src/defaults/inMemoryDataAdapter.ts
@@ -45,6 +45,9 @@ export class InMemoryDataAdapter implements IIdempotencyDataAdapter {
         const findIndex = this.idempotencyResources.findIndex(
             (x) => x.idempotencyKey === idempotencyResource.idempotencyKey
         );
+        if (findIndex < 0) {
+            return;
+        }
         this.idempotencyResources[findIndex] = idempotencyResource;
     }
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -49,6 +49,15 @@ export interface IdempotencyResource {
      * be returned for a matching idempotency key.
      */
     response?: IdempotencyResponse;
+
+    /**
+     * Timestamp set by the middleware when the resource is created (processing start).
+     * Used by the `processingTimeout` lease mechanism to detect orphaned in-progress
+     * resources and allow a subsequent request to take over processing.
+     * Adapters must persist and return this field for the expiry feature to be active;
+     * if absent, the resource is treated as non-expired (safe degradation).
+     */
+    createdAt?: Date | number;
 }
 
 /**
@@ -130,4 +139,16 @@ export interface IdempotencyOptions {
     // Validate the intent of the request
     // Default is the DefaultIntentValidator.
     intentValidator?: IIdempotencyIntentValidator;
+    /**
+     * Maximum time in milliseconds allowed for a request to complete before its
+     * in-progress resource is considered orphaned and can be taken over by a
+     * subsequent retry. Values of `undefined`, `0`, or any non-positive / non-finite
+     * number disable the feature (default: disabled — behaviour identical to v2.0.0).
+     * Requires the data adapter to persist and return `IdempotencyResource.createdAt`;
+     * without it the feature is silently inert.
+     * Choose a value at least 2× the worst-case processing duration to avoid false
+     * takeovers. Note: due to the check-then-act nature of the takeover, at-least-once
+     * delivery semantics apply when the timeout is reached.
+     */
+    processingTimeout?: number;
 }

--- a/src/services/idempotencyService.test.ts
+++ b/src/services/idempotencyService.test.ts
@@ -13,6 +13,7 @@ import { IdempotencyService } from './idempotencyService';
 import * as express from 'express';
 import sinon from 'sinon';
 import * as HttpStatus from 'http-status-codes';
+import { EventEmitter } from 'events';
 
 describe('Idempotency service', () => {
     let idempotencyService: IdempotencyService = null;
@@ -669,5 +670,88 @@ describe('Idempotency service — processingTimeout (lease/takeover)', () => {
         await wait(1);
 
         assert.isTrue(updateSpy.calledOnce);
+    });
+});
+
+describe('Idempotency service — finish hook (res.end bypass)', () => {
+    let dataAdapter: InMemoryDataAdapter = null;
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    function makeService(): IdempotencyService {
+        dataAdapter = new InMemoryDataAdapter();
+        return new IdempotencyService({
+            idempotencyKeyHeader: 'idempotency-key',
+            intentValidator: new DefaultIntentValidator(),
+            dataAdapter,
+            responseValidator: new SuccessfulResponseValidator(),
+        });
+    }
+
+    it('res.end without res.send — resource deleted, warn emitted, next request reprocessed', async () => {
+        const svc = makeService();
+        const req = createRequest();
+
+        // EventEmitter is required for node-mocks-http to emit the finish event
+        const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+        const warnSpy = sinon.stub(console, 'warn');
+        const deleteSpy = sinon.spy(dataAdapter, 'delete');
+
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            res,
+            sinon.spy()
+        );
+
+        // Simulate res.end() — bypasses the monkey-patched res.send
+        res.end();
+        await wait(1);
+
+        assert.isTrue(warnSpy.called, 'console.warn should be called');
+        assert.isTrue(deleteSpy.calledOnce, 'resource should be deleted');
+
+        // Next request with same key must be reprocessed (not 409)
+        const retryNext = sinon.spy();
+        const retryReq = createCloneRequest(req);
+        await svc.provideMiddlewareFunction(
+            retryReq,
+            httpMocks.createResponse(),
+            retryNext
+        );
+
+        assert.isTrue(retryNext.calledOnce);
+        assert.isFalse(
+            svc.isHit(retryReq),
+            'retry should not be a hit — it must be reprocessed'
+        );
+    });
+
+    it('finish after res.send — update called once, delete not called, no warn', async () => {
+        const svc = makeService();
+        const req = createRequest();
+
+        const res = httpMocks.createResponse({ eventEmitter: EventEmitter });
+        const warnSpy = sinon.stub(console, 'warn');
+        const updateSpy = sinon.spy(dataAdapter, 'update');
+        const deleteSpy = sinon.spy(dataAdapter, 'delete');
+
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            res,
+            sinon.spy()
+        );
+
+        // Normal path: res.send triggers the monkey-patch, then finish fires
+        res.send('body');
+        await wait(1);
+
+        assert.isTrue(updateSpy.calledOnce, 'update should be called once');
+        assert.isFalse(deleteSpy.called, 'delete should not be called');
+        assert.isFalse(
+            warnSpy.called,
+            'warn should not be emitted on normal send path'
+        );
     });
 });

--- a/src/services/idempotencyService.test.ts
+++ b/src/services/idempotencyService.test.ts
@@ -12,6 +12,7 @@ import * as httpMocks from 'node-mocks-http';
 import { IdempotencyService } from './idempotencyService';
 import * as express from 'express';
 import sinon from 'sinon';
+import * as HttpStatus from 'http-status-codes';
 
 describe('Idempotency service', () => {
     let idempotencyService: IdempotencyService = null;
@@ -239,3 +240,434 @@ async function wait(ms: number) {
         setTimeout(resolve, ms);
     });
 }
+
+describe('Idempotency service — processingTimeout (lease/takeover)', () => {
+    let dataAdapter: InMemoryDataAdapter = null;
+    let responseValidator: SuccessfulResponseValidator = null;
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    function makeService(processingTimeout?: number): IdempotencyService {
+        dataAdapter = new InMemoryDataAdapter();
+        responseValidator = new SuccessfulResponseValidator();
+        return new IdempotencyService({
+            idempotencyKeyHeader: 'idempotency-key',
+            intentValidator: new DefaultIntentValidator(),
+            dataAdapter,
+            responseValidator,
+            processingTimeout,
+        });
+    }
+
+    it('regression: no processingTimeout — in-progress resource returns 409', async () => {
+        const svc = makeService();
+        const req = createRequest();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        const conflictNext = sinon.spy();
+        const conflictRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            conflictRes,
+            conflictNext
+        );
+
+        assert.isTrue(conflictNext.calledOnce);
+        assert.equal(conflictRes.statusCode, HttpStatus.CONFLICT);
+    });
+
+    it('age within timeout — in-progress resource still returns 409', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        // Advance time but stay under timeout
+        clock.tick(3000);
+
+        const conflictNext = sinon.spy();
+        const conflictRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            conflictRes,
+            conflictNext
+        );
+
+        assert.equal(conflictRes.statusCode, HttpStatus.CONFLICT);
+    });
+
+    it('age exceeds timeout — takeover: next called, isHit false, response cached for third request', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const originalReq = createRequest();
+
+        // First request: creates the resource but never sends a response
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(originalReq),
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        // Advance past timeout
+        clock.tick(6000);
+
+        // Takeover request
+        const takeoverNext = sinon.spy();
+        const takeoverRes = httpMocks.createResponse();
+        const takeoverReq = createCloneRequest(originalReq);
+        await svc.provideMiddlewareFunction(
+            takeoverReq,
+            takeoverRes,
+            takeoverNext
+        );
+
+        assert.isTrue(takeoverNext.calledOnce);
+        assert.isFalse(svc.isHit(takeoverReq));
+
+        // Takeover sends its response
+        takeoverRes.send('takeover-body');
+        await wait(1);
+
+        // Third request: should replay the cached response
+        const replayReq = createCloneRequest(originalReq);
+        const replayRes = httpMocks.createResponse();
+        const replayNext = sinon.spy();
+        await svc.provideMiddlewareFunction(replayReq, replayRes, replayNext);
+
+        assert.isTrue(replayNext.calledOnce);
+        assert.isTrue(svc.isHit(replayReq));
+        assert.equal(replayRes._getData(), 'takeover-body');
+    });
+
+    it('resource without createdAt (legacy adapter) — returns 409 even if timeout enabled', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        // Stub findByIdempotencyKey to return a resource without createdAt
+        const stubFind = sinon.stub(dataAdapter, 'findByIdempotencyKey');
+        const fakeResource: IdempotencyResource = {
+            idempotencyKey: req.get('idempotency-key'),
+            request: {
+                url: req.url,
+                method: req.method,
+                body: {},
+                headers: req.headers,
+                query: {},
+            },
+        };
+        stubFind.onFirstCall().resolves(null); // create path
+        stubFind.resolves(fakeResource); // subsequent reads return resource without createdAt
+        const stubCreate = sinon.stub(dataAdapter, 'create').resolves();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        clock.tick(10000);
+
+        const conflictNext = sinon.spy();
+        const conflictRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            conflictRes,
+            conflictNext
+        );
+
+        assert.equal(conflictRes.statusCode, HttpStatus.CONFLICT);
+    });
+
+    it('createdAt as epoch ms — expiry computed correctly', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        const stubFind = sinon.stub(dataAdapter, 'findByIdempotencyKey');
+        const fakeResource: IdempotencyResource = {
+            idempotencyKey: req.get('idempotency-key'),
+            request: {
+                url: req.url,
+                method: req.method,
+                body: {},
+                headers: req.headers,
+                query: {},
+            },
+            createdAt: Date.now(), // numeric epoch
+        };
+        stubFind.onFirstCall().resolves(null);
+        stubFind.resolves(fakeResource);
+        sinon.stub(dataAdapter, 'create').resolves();
+        sinon.stub(dataAdapter, 'delete').resolves();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+        clock.tick(6000);
+
+        const takeoverNext = sinon.spy();
+        const takeoverReq = createCloneRequest(req);
+        await svc.provideMiddlewareFunction(
+            takeoverReq,
+            httpMocks.createResponse(),
+            takeoverNext
+        );
+
+        assert.isTrue(takeoverNext.calledOnce);
+        assert.isFalse(svc.isHit(takeoverReq));
+    });
+
+    it('createdAt as ISO string — expiry computed correctly', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        const stubFind = sinon.stub(dataAdapter, 'findByIdempotencyKey');
+        const fakeResource: IdempotencyResource = {
+            idempotencyKey: req.get('idempotency-key'),
+            request: {
+                url: req.url,
+                method: req.method,
+                body: {},
+                headers: req.headers,
+                query: {},
+            },
+            createdAt: new Date().toISOString() as any, // string from JSON round-trip
+        };
+        stubFind.onFirstCall().resolves(null);
+        stubFind.resolves(fakeResource);
+        sinon.stub(dataAdapter, 'create').resolves();
+        sinon.stub(dataAdapter, 'delete').resolves();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+        clock.tick(6000);
+
+        const takeoverNext = sinon.spy();
+        const takeoverReq = createCloneRequest(req);
+        await svc.provideMiddlewareFunction(
+            takeoverReq,
+            httpMocks.createResponse(),
+            takeoverNext
+        );
+
+        assert.isTrue(takeoverNext.calledOnce);
+        assert.isFalse(svc.isHit(takeoverReq));
+    });
+
+    it('createdAt non-parseable (garbage string) — no takeover, returns 409', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        const stubFind = sinon.stub(dataAdapter, 'findByIdempotencyKey');
+        const fakeResource: IdempotencyResource = {
+            idempotencyKey: req.get('idempotency-key'),
+            request: {
+                url: req.url,
+                method: req.method,
+                body: {},
+                headers: req.headers,
+                query: {},
+            },
+            createdAt: 'not-a-date' as any,
+        };
+        stubFind.onFirstCall().resolves(null);
+        stubFind.resolves(fakeResource);
+        sinon.stub(dataAdapter, 'create').resolves();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        // Advance well past timeout — parseCreatedAt returns null for garbage string
+        // so isLeaseExpired returns false and the behaviour is 409, not a takeover.
+        clock.tick(10000);
+
+        const conflictNext = sinon.spy();
+        const conflictRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            conflictRes,
+            conflictNext
+        );
+
+        assert.equal(conflictRes.statusCode, HttpStatus.CONFLICT);
+        assert.isTrue(conflictNext.calledOnce);
+    });
+
+    it('create throws at takeover — falls back to 409 with no unhandled rejection', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const req = createRequest();
+
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+
+        clock.tick(6000);
+
+        // Make create throw to simulate lost race condition
+        sinon.stub(dataAdapter, 'create').rejects(new Error('Duplicate'));
+
+        const fallbackNext = sinon.spy();
+        const fallbackRes = httpMocks.createResponse();
+        const fallbackReq = createCloneRequest(req);
+
+        // Must not throw / produce unhandled rejection
+        await svc.provideMiddlewareFunction(
+            fallbackReq,
+            fallbackRes,
+            fallbackNext
+        );
+
+        assert.isTrue(fallbackNext.calledOnce);
+        assert.equal(fallbackRes.statusCode, HttpStatus.CONFLICT);
+    });
+
+    it('lease expired + intent divergent — returns 417, no takeover', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const idempotencyKey = faker.string.uuid();
+
+        const req1 = httpMocks.createRequest({
+            url: 'https://endpoint-a',
+            method: 'POST',
+            headers: { 'idempotency-key': idempotencyKey },
+        });
+        const req2 = httpMocks.createRequest({
+            url: 'https://endpoint-b',
+            method: 'POST',
+            headers: { 'idempotency-key': idempotencyKey },
+        });
+
+        await svc.provideMiddlewareFunction(
+            req1,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+        clock.tick(6000);
+
+        const deleteSpy = sinon.spy(dataAdapter, 'delete');
+        const intentNext = sinon.spy();
+        const intentRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(req2, intentRes, intentNext);
+
+        assert.equal(intentRes.statusCode, HttpStatus.EXPECTATION_FAILED);
+        assert.isFalse(
+            deleteSpy.called,
+            'delete should not be called for intent mismatch'
+        );
+    });
+
+    it('zombie guard: late send after takeover — does not overwrite new resource', async () => {
+        const clock = sinon.useFakeTimers({
+            now: Date.now(),
+            toFake: ['Date'],
+        });
+        const svc = makeService(5000);
+        const originalReq = createRequest();
+
+        // First request: sets up hook but never sends
+        const firstRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(originalReq),
+            firstRes,
+            sinon.spy()
+        );
+
+        const updateSpy = sinon.spy(dataAdapter, 'update');
+
+        // Advance past timeout, takeover
+        clock.tick(6000);
+        const takeoverRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(originalReq),
+            takeoverRes,
+            sinon.spy()
+        );
+        takeoverRes.send('takeover-body');
+        await wait(1);
+
+        // Original (zombie) finally sends — should NOT call update on the new resource
+        const updateCallsBefore = updateSpy.callCount;
+        firstRes.send('zombie-body');
+        await wait(1);
+
+        assert.equal(
+            updateSpy.callCount,
+            updateCallsBefore,
+            'zombie must not call update'
+        );
+
+        // Third request should still replay the takeover body
+        const replayReq = createCloneRequest(originalReq);
+        const replayRes = httpMocks.createResponse();
+        await svc.provideMiddlewareFunction(replayReq, replayRes, sinon.spy());
+        assert.equal(replayRes._getData(), 'takeover-body');
+    });
+
+    it('zombie guard: late send without takeover (timeout disabled) — response is persisted normally', async () => {
+        const svc = makeService(); // no timeout
+        const req = createRequest();
+        const res = httpMocks.createResponse();
+
+        await svc.provideMiddlewareFunction(
+            createCloneRequest(req),
+            res,
+            sinon.spy()
+        );
+
+        const updateSpy = sinon.spy(dataAdapter, 'update');
+        res.send('late-body');
+        await wait(1);
+
+        assert.isTrue(updateSpy.calledOnce);
+    });
+});

--- a/src/services/idempotencyService.ts
+++ b/src/services/idempotencyService.ts
@@ -218,7 +218,39 @@ export class IdempotencyService {
         // Wait for send() to be called to build the Response. To ensure performance,
         // fire and forget.
         const idempotencyKey: string = resource.idempotencyKey;
-        this.sendHook(res)
+
+        // Tracks whether res.send was called. Set synchronously inside the
+        // monkey-patched send so the finish handler can distinguish a normal
+        // send path from a bypass (res.end / streaming / sendFile).
+        let settled = false;
+
+        // Cleanup hook: fires when the HTTP response is fully flushed. If
+        // res.send was never called (settled is false), the body was not
+        // captured — delete the resource so the next retry is processed
+        // fresh instead of receiving a permanent 409.
+        res.once('finish', () => {
+            if (settled) {
+                return;
+            }
+            console.warn(
+                'Response sent without res.send — idempotency resource will be deleted.'
+            );
+            this.canStillPersist(resource)
+                .then(async (canPersist) => {
+                    if (canPersist) {
+                        await this._options.dataAdapter.delete(idempotencyKey);
+                    }
+                })
+                .catch(() => {
+                    console.warn(
+                        'Error while deleting idempotency resource after finish without send.'
+                    );
+                });
+        });
+
+        this.sendHook(res, () => {
+            settled = true;
+        })
             .then(async (body) => {
                 // Receive everything required to assemble a idempotency response.
                 // logger.info(headers);
@@ -276,13 +308,20 @@ export class IdempotencyService {
 
     /**
      * Hook into send function of the response to receive the body.
+     * The optional `onSend` callback is invoked synchronously as the very first
+     * thing inside the patched send, before the promise resolves — this ensures
+     * any flag (e.g. `settled`) is set before the `finish` event fires.
      * @param res
+     * @param onSend Optional synchronous callback invoked when send is called
      */
-    private sendHook(res: express.Response): Promise<any> {
+    private sendHook(res: express.Response, onSend?: () => void): Promise<any> {
         return new Promise<any>((resolve) => {
             const defaultSend = res.send.bind(res);
             // @ts-ignore
             res.send = (body?: any) => {
+                if (onSend) {
+                    onSend();
+                }
                 resolve(body);
                 defaultSend(body);
             };

--- a/src/services/idempotencyService.ts
+++ b/src/services/idempotencyService.ts
@@ -43,12 +43,21 @@ export class IdempotencyService {
         const intentValidator =
             options.intentValidator ?? new DefaultIntentValidator();
 
+        // Normalise processingTimeout: undefined/0/negative/non-finite = feature disabled.
+        const processingTimeout =
+            typeof options.processingTimeout === 'number' &&
+            isFinite(options.processingTimeout) &&
+            options.processingTimeout > 0
+                ? options.processingTimeout
+                : undefined;
+
         // Ensure that every propery has a value.
         this._options = {
             idempotencyKeyHeader,
             dataAdapter,
             responseValidator,
             intentValidator,
+            processingTimeout,
         };
     }
 
@@ -83,11 +92,39 @@ export class IdempotencyService {
                 // idempotency key function. This could also lead to security vulnerability
                 // because someone could send random key to get response.
                 if (
-                    this._options.intentValidator.isValidIntent(
+                    !this._options.intentValidator.isValidIntent(
                         req,
                         resource.request
                     )
                 ) {
+                    // Invalid intent. Client must correct his request.
+                    const invalidIntentError = new Error(
+                        'Misuse of the idempotency key. Please check your request.'
+                    );
+                    res.status(HttpStatus.EXPECTATION_FAILED);
+                    next(invalidIntentError);
+                } else if (this.isLeaseExpired(resource)) {
+                    // Orphaned in-progress resource: a previous request started but never
+                    // persisted its response. Take over processing.
+                    delete req.headers[HIT_HEADER];
+                    try {
+                        await this._options.dataAdapter.delete(idempotencyKey);
+                        const newResource: IdempotencyResource = {
+                            idempotencyKey,
+                            request: this.convertToIdempotencyRequest(req),
+                            createdAt: new Date(),
+                        };
+                        await this.startProcessing(res, newResource, next);
+                    } catch {
+                        // Takeover lost (concurrent retry won the create constraint) or
+                        // delete failed — fall back to the standard 409.
+                        const conflictError = new Error(
+                            'A previous request is still in progress for this key.'
+                        );
+                        res.status(HttpStatus.CONFLICT);
+                        next(conflictError);
+                    }
+                } else {
                     const availableResponse = resource.response;
                     if (availableResponse) {
                         // Set original headers
@@ -112,23 +149,15 @@ export class IdempotencyService {
                         res.status(HttpStatus.CONFLICT);
                         next(conflictError);
                     }
-                } else {
-                    // Invalid intent. Client must correct his request.
-                    const invalidIntentError = new Error(
-                        'Misuse of the idempotency key. Please check your request.'
-                    );
-                    res.status(HttpStatus.EXPECTATION_FAILED);
-                    next(invalidIntentError);
                 }
             } else {
                 // No resource, so initiate the idempotency process
-                resource = {
+                const newResource: IdempotencyResource = {
                     idempotencyKey,
                     request: this.convertToIdempotencyRequest(req),
+                    createdAt: new Date(),
                 };
-                await this._options.dataAdapter.create(resource);
-                this.setupHooks(res, resource);
-                next();
+                await this.startProcessing(res, newResource, next);
             }
         } else {
             next();
@@ -206,13 +235,21 @@ export class IdempotencyService {
                             response
                         )
                     ) {
-                        const newResource: IdempotencyResource = {
-                            ...resource,
-                            response,
-                        };
-                        await this._options.dataAdapter.update(newResource);
+                        if (await this.canStillPersist(resource)) {
+                            const updatedResource: IdempotencyResource = {
+                                ...resource,
+                                response,
+                            };
+                            await this._options.dataAdapter.update(
+                                updatedResource
+                            );
+                        }
                     } else {
-                        await this._options.dataAdapter.delete(idempotencyKey);
+                        if (await this.canStillPersist(resource)) {
+                            await this._options.dataAdapter.delete(
+                                idempotencyKey
+                            );
+                        }
                     }
                 } catch (err) {
                     console.log(
@@ -226,7 +263,9 @@ export class IdempotencyService {
                     console.log(
                         'Something went wrong, try to remove idempotency...'
                     );
-                    await this._options.dataAdapter.delete(idempotencyKey);
+                    if (await this.canStillPersist(resource)) {
+                        await this._options.dataAdapter.delete(idempotencyKey);
+                    }
                 } catch {
                     console.log(
                         'Error while removing idempotency key during failing hook.'
@@ -277,5 +316,102 @@ export class IdempotencyService {
             body,
             headers,
         };
+    }
+
+    /**
+     * Initiate processing for a new (or taken-over) resource: persist it, set up
+     * response hooks, and call next.
+     * @param res Express response
+     * @param resource Freshly built resource (with createdAt stamped)
+     * @param next Express next function
+     */
+    private async startProcessing(
+        res: express.Response,
+        resource: IdempotencyResource,
+        next: express.NextFunction
+    ): Promise<void> {
+        await this._options.dataAdapter.create(resource);
+        this.setupHooks(res, resource);
+        next();
+    }
+
+    /**
+     * Parse a `createdAt` value into a Unix timestamp (ms).
+     * Accepts a Date object, a numeric epoch, or a string that can be parsed by
+     * the Date constructor (e.g. ISO 8601 produced by JSON serialisation of a Date).
+     * Returns null when the value is absent, not parseable, or results in NaN.
+     * @param value Raw createdAt value from the resource
+     */
+    private parseCreatedAt(value: Date | number | any): number | null {
+        if (value === undefined || value === null) {
+            return null;
+        }
+        if (value instanceof Date) {
+            const ms = value.getTime();
+            return isNaN(ms) ? null : ms;
+        }
+        if (typeof value === 'number') {
+            return isNaN(value) ? null : value;
+        }
+        // String (e.g. ISO date from JSON round-trip through an adapter)
+        const ms = new Date(value).getTime();
+        return isNaN(ms) ? null : ms;
+    }
+
+    /**
+     * Determine whether the in-progress lease for the given resource has expired.
+     * Returns false (not expired) when processingTimeout is disabled, when createdAt
+     * is absent or non-parseable, or when the resource is still within the timeout window.
+     * @param resource Resource to evaluate
+     */
+    private isLeaseExpired(resource: IdempotencyResource): boolean {
+        const timeout = this._options.processingTimeout;
+        if (!timeout) {
+            return false;
+        }
+        const ageMs = this.parseCreatedAt(resource.createdAt);
+        if (ageMs === null) {
+            return false;
+        }
+        return Date.now() - ageMs > timeout;
+    }
+
+    /**
+     * Determine whether the current hook is still the legitimate owner of the resource
+     * and is allowed to persist its response. Guards against zombie writes after a
+     * takeover has occurred.
+     * On the nominal path (age within timeout or timeout disabled) returns true with no
+     * extra adapter read. Only performs a refetch when our own lease has already expired.
+     * @param resource The resource snapshot captured at hook setup time
+     */
+    private async canStillPersist(
+        resource: IdempotencyResource
+    ): Promise<boolean> {
+        const timeout = this._options.processingTimeout;
+        if (!timeout) {
+            return true;
+        }
+        const ageMs = this.parseCreatedAt(resource.createdAt);
+        if (ageMs === null || Date.now() - ageMs <= timeout) {
+            return true;
+        }
+        // Our lease has expired — refetch to check whether a takeover replaced us.
+        const current = await this._options.dataAdapter.findByIdempotencyKey(
+            resource.idempotencyKey
+        );
+        if (!current) {
+            console.warn(
+                'Skipping late persistence: resource was taken over and deleted.'
+            );
+            return false;
+        }
+        const currentAge = this.parseCreatedAt(current.createdAt);
+        if (currentAge !== ageMs) {
+            console.warn(
+                'Skipping late persistence: resource was replaced by a newer request.'
+            );
+            return false;
+        }
+        return true;
     }
 }

--- a/src/services/idempotencyService.ts
+++ b/src/services/idempotencyService.ts
@@ -43,13 +43,13 @@ export class IdempotencyService {
         const intentValidator =
             options.intentValidator ?? new DefaultIntentValidator();
 
-        // Normalise processingTimeout: undefined/0/negative/non-finite = feature disabled.
+        // Normalise processingTimeout: absent/0/negative/non-finite = feature disabled (0).
         const processingTimeout =
             typeof options.processingTimeout === 'number' &&
             isFinite(options.processingTimeout) &&
             options.processingTimeout > 0
                 ? options.processingTimeout
-                : undefined;
+                : 0;
 
         // Ensure that every propery has a value.
         this._options = {
@@ -106,7 +106,7 @@ export class IdempotencyService {
                 } else if (this.isLeaseExpired(resource)) {
                     // Orphaned in-progress resource: a previous request started but never
                     // persisted its response. Take over processing.
-                    delete req.headers[HIT_HEADER];
+                    Reflect.deleteProperty(req.headers, HIT_HEADER);
                     try {
                         await this._options.dataAdapter.delete(idempotencyKey);
                         const newResource: IdempotencyResource = {
@@ -232,7 +232,7 @@ export class IdempotencyService {
             if (settled) {
                 return;
             }
-            console.warn(
+            this.logWarning(
                 'Response sent without res.send — idempotency resource will be deleted.'
             );
             this.canStillPersist(resource)
@@ -242,7 +242,7 @@ export class IdempotencyService {
                     }
                 })
                 .catch(() => {
-                    console.warn(
+                    this.logWarning(
                         'Error while deleting idempotency resource after finish without send.'
                     );
                 });
@@ -382,17 +382,11 @@ export class IdempotencyService {
      * @param value Raw createdAt value from the resource
      */
     private parseCreatedAt(value: Date | number | any): number | null {
-        if (value === undefined || value === null) {
+        // The Date constructor would coerce null to epoch 0 — reject it explicitly.
+        // An absent value yields an invalid date, handled by the NaN guard below.
+        if (value === null) {
             return null;
         }
-        if (value instanceof Date) {
-            const ms = value.getTime();
-            return isNaN(ms) ? null : ms;
-        }
-        if (typeof value === 'number') {
-            return isNaN(value) ? null : value;
-        }
-        // String (e.g. ISO date from JSON round-trip through an adapter)
         const ms = new Date(value).getTime();
         return isNaN(ms) ? null : ms;
     }
@@ -426,31 +420,32 @@ export class IdempotencyService {
     private async canStillPersist(
         resource: IdempotencyResource
     ): Promise<boolean> {
-        const timeout = this._options.processingTimeout;
-        if (!timeout) {
-            return true;
-        }
-        const ageMs = this.parseCreatedAt(resource.createdAt);
-        if (ageMs === null || Date.now() - ageMs <= timeout) {
+        if (!this.isLeaseExpired(resource)) {
             return true;
         }
         // Our lease has expired — refetch to check whether a takeover replaced us.
         const current = await this._options.dataAdapter.findByIdempotencyKey(
             resource.idempotencyKey
         );
-        if (!current) {
-            console.warn(
-                'Skipping late persistence: resource was taken over and deleted.'
+        const stillOwner =
+            current &&
+            this.parseCreatedAt(current.createdAt) ===
+                this.parseCreatedAt(resource.createdAt);
+        if (!stillOwner) {
+            this.logWarning(
+                'Skipping late persistence: resource was taken over by a newer request.'
             );
-            return false;
         }
-        const currentAge = this.parseCreatedAt(current.createdAt);
-        if (currentAge !== ageMs) {
-            console.warn(
-                'Skipping late persistence: resource was replaced by a newer request.'
-            );
-            return false;
-        }
-        return true;
+        return !!stillOwner;
+    }
+
+    /**
+     * Emit an internal warning. Centralised so it can be replaced by a
+     * pluggable logger in a future release without touching call sites.
+     * @param message Warning message
+     */
+    private logWarning(message: string): void {
+        // eslint-disable-next-line no-console
+        console.warn(message);
     }
 }

--- a/tests/e2e/harness/buildApp.ts
+++ b/tests/e2e/harness/buildApp.ts
@@ -1,0 +1,123 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+import express = require('express');
+import { idempotency, getSharedIdempotencyService } from '../../../src/index';
+import {
+    IdempotencyOptions,
+    IIdempotencyDataAdapter,
+} from '../../../src/models/models';
+import { IdempotencyService } from '../../../src/services/idempotencyService';
+import { InMemoryDataAdapter } from '../../../src/defaults/inMemoryDataAdapter';
+import { Controls, makeControls } from './controls';
+
+export interface BuiltApp {
+    app: express.Express;
+    service: IdempotencyService;
+    controls: Controls;
+}
+
+/**
+ * Wrap a data adapter to record deletions through the test controls, so a test
+ * can await asynchronous cleanup (phantom-key removal, reportError) via
+ * `controls.wasDeleted(key)`. Every operation is delegated to the inner adapter.
+ */
+function traceAdapter(
+    inner: IIdempotencyDataAdapter,
+    controls: Controls
+): IIdempotencyDataAdapter {
+    return {
+        findByIdempotencyKey: (key) => inner.findByIdempotencyKey(key),
+        create: (resource) => inner.create(resource),
+        update: (resource) => inner.update(resource),
+        delete: async (key) => {
+            await inner.delete(key);
+            controls.recordDelete(key);
+        },
+    };
+}
+
+/**
+ * Build a mini Express app exercising the idempotency middleware over a real
+ * HTTP stack. Routes are instrumented through `controls` so tests can drive
+ * conflicts, timeouts and phantom keys deterministically.
+ *
+ * IMPORTANT: the middleware factory mutates a process-wide singleton, so the
+ * service instance is captured here and used by the handlers through closure —
+ * never via getSharedIdempotencyService() inside a handler (it would return the
+ * last app built, breaking isolation).
+ */
+export function buildApp(
+    options: IdempotencyOptions = {},
+    controls: Controls = makeControls()
+): BuiltApp {
+    const innerAdapter = options.dataAdapter ?? new InMemoryDataAdapter();
+    const dataAdapter = traceAdapter(innerAdapter, controls);
+
+    const middleware = idempotency({ ...options, dataAdapter });
+    const service = getSharedIdempotencyService();
+
+    const app = express();
+    app.use(express.json());
+    app.use(middleware);
+
+    // Normal route — exercises replay / hit / intent validation.
+    app.all('/resource', (req, res) => {
+        if (service.isHit(req)) {
+            return;
+        }
+        const n = controls.bump('/resource');
+        res.json({ value: String(n), callCount: n });
+    });
+
+    // Slow route — holds in-progress until released; drives 409, concurrent
+    // retries, timeout takeover and the zombie guard. The gate is keyed by
+    // execution index so each in-flight execution is released independently.
+    app.get('/slow', async (req, res) => {
+        if (service.isHit(req)) {
+            return;
+        }
+        const n = controls.bump('/slow');
+        await controls.gate(`/slow#${n}`);
+        res.json({ callCount: n, instance: n });
+    });
+
+    // Bypass route — responds via res.end() without res.send(), so the
+    // middleware must clean up the orphaned resource on finish (phantom key).
+    app.get('/raw-end', (req, res) => {
+        if (service.isHit(req)) {
+            return;
+        }
+        controls.bump('/raw-end');
+        res.status(200).end('raw');
+    });
+
+    // Failing route — reports a business error so the key is released for retry.
+    app.get('/boom', async (req, res) => {
+        controls.bump('/boom');
+        await service.reportError(req);
+        res.status(500).json({ error: 'boom' });
+    });
+
+    // Error handler: the middleware sets res.status(409|417) then calls
+    // next(err); without an explicit handler Express would emit 500. Real
+    // consumers must provide an equivalent handler — this is a documented part
+    // of the middleware contract.
+    app.use(
+        (
+            err: Error,
+            _req: express.Request,
+            res: express.Response,
+            _next: express.NextFunction
+        ) => {
+            if (res.headersSent) {
+                return;
+            }
+            const code = res.statusCode >= 400 ? res.statusCode : 500;
+            res.status(code).json({ error: err.message });
+        }
+    );
+
+    return { app, service, controls };
+}

--- a/tests/e2e/harness/client.ts
+++ b/tests/e2e/harness/client.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+// Per-request safety timeout: turns a handler parked forever (a bug, or a gate
+// never released) into an explicit AbortError well before Mocha's global
+// timeout, instead of an opaque hang. No legitimate scenario parks a request
+// this long.
+const REQUEST_TIMEOUT_MS = 8000;
+
+export interface E2EResponse {
+    status: number;
+    headers: Record<string, string>;
+    body: any;
+}
+
+export interface E2ERequestOptions {
+    path: string;
+    method?: string;
+    key?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+    signal?: AbortSignal;
+}
+
+/**
+ * Perform a real HTTP request against the running harness server using the
+ * native fetch (Node >= 18). Parses JSON when the response advertises it,
+ * otherwise returns the raw text body. Falls back to a safety timeout when no
+ * explicit AbortSignal is provided.
+ */
+export async function req(
+    baseUrl: string,
+    options: E2ERequestOptions
+): Promise<E2EResponse> {
+    const headers: Record<string, string> = { ...(options.headers ?? {}) };
+    if (options.key) {
+        headers['Idempotency-Key'] = options.key;
+    }
+    let payload: string | undefined;
+    if (options.body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        payload = JSON.stringify(options.body);
+    }
+
+    const response = await fetch(`${baseUrl}${options.path}`, {
+        method: options.method ?? 'GET',
+        headers,
+        body: payload,
+        signal: options.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, name) => {
+        responseHeaders[name] = value;
+    });
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const body = contentType.includes('application/json')
+        ? await response.json()
+        : await response.text();
+
+    return { status: response.status, headers: responseHeaders, body };
+}

--- a/tests/e2e/harness/controls.ts
+++ b/tests/e2e/harness/controls.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+/**
+ * Deferred promise: an externally-resolvable promise used as a "gate" so a test
+ * can hold a request handler in-progress and release it deterministically.
+ */
+interface Deferred {
+    promise: Promise<void>;
+    resolve: () => void;
+}
+
+function createDeferred(): Deferred {
+    let resolve!: () => void;
+    const promise = new Promise<void>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+/**
+ * Test controls shared between the harness server and a test case:
+ * - gates: hold handlers in-progress until the test releases them;
+ * - counters: count real handler executions (proof of hit vs takeover);
+ * - deleted: track keys removed through the data adapter (cleanup assertions).
+ */
+export interface Controls {
+    /** Await inside a handler; resolves when the test calls release(key). */
+    gate(key: string): Promise<void>;
+    /** Release a specific gate. */
+    release(key: string): void;
+    /** Release every pending gate (use in afterEach to avoid hanging). */
+    releaseAll(): void;
+    /** Increment and return the execution counter for a route. */
+    bump(route: string): number;
+    /** Read the execution counter for a route. */
+    count(route: string): number;
+    /** Record that a key was deleted through the data adapter. */
+    recordDelete(key: string): void;
+    /** Indicate whether a key was deleted through the data adapter. */
+    wasDeleted(key: string): boolean;
+}
+
+export function makeControls(): Controls {
+    const gates = new Map<string, Deferred>();
+    const counters = new Map<string, number>();
+    const deleted = new Set<string>();
+
+    function gateFor(key: string): Deferred {
+        let d = gates.get(key);
+        if (!d) {
+            d = createDeferred();
+            gates.set(key, d);
+        }
+        return d;
+    }
+
+    return {
+        gate(key: string): Promise<void> {
+            return gateFor(key).promise;
+        },
+        release(key: string): void {
+            gateFor(key).resolve();
+        },
+        releaseAll(): void {
+            for (const d of gates.values()) {
+                d.resolve();
+            }
+        },
+        bump(route: string): number {
+            const n = (counters.get(route) ?? 0) + 1;
+            counters.set(route, n);
+            return n;
+        },
+        count(route: string): number {
+            return counters.get(route) ?? 0;
+        },
+        recordDelete(key: string): void {
+            deleted.add(key);
+        },
+        wasDeleted(key: string): boolean {
+            return deleted.has(key);
+        },
+    };
+}

--- a/tests/e2e/harness/helpers.ts
+++ b/tests/e2e/harness/helpers.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+import { faker } from '@faker-js/faker';
+
+/**
+ * Generate a unique idempotency key for a test case.
+ */
+export function genKey(): string {
+    return faker.string.uuid();
+}
+
+/**
+ * Resolve after the given delay (real time).
+ */
+export function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll a predicate until it becomes true or the timeout elapses. Used to await
+ * asynchronous side effects (resource creation, cleanup) without relying on
+ * fixed sleeps — keeps the suite robust on slow CI machines.
+ */
+export async function waitUntil(
+    predicate: () => boolean,
+    timeoutMs = 2000,
+    intervalMs = 10
+): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error('waitUntil: condition not met before timeout');
+        }
+        await wait(intervalMs);
+    }
+}
+
+/**
+ * Fire `count` invocations of `fn` concurrently and wait for all to settle.
+ */
+export function concurrent<T>(
+    count: number,
+    fn: (index: number) => Promise<T>
+): Promise<PromiseSettledResult<T>[]> {
+    return Promise.allSettled(
+        Array.from({ length: count }, (_unused, i) => fn(i))
+    );
+}

--- a/tests/e2e/harness/scenarios.ts
+++ b/tests/e2e/harness/scenarios.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+import { assert } from 'chai';
+import { IdempotencyOptions } from '../../../src/models/models';
+import { BuiltApp } from './buildApp';
+import { startServer, RunningServer } from './server';
+import { genKey, wait, waitUntil, concurrent } from './helpers';
+
+/**
+ * Run the full idempotency behavioural suite against a given app factory.
+ * Reusable across data adapters: pass a factory that injects another adapter
+ * (e.g. a MongoDB adapter) to replay the exact same guarantees over real HTTP.
+ */
+export function runIdempotencySuite(
+    makeApp: (options?: IdempotencyOptions) => BuiltApp
+): void {
+    describe('express-idempotency e2e behaviour', () => {
+        let built: BuiltApp | undefined;
+        let ctx: RunningServer | undefined;
+
+        async function start(options?: IdempotencyOptions): Promise<void> {
+            built = makeApp(options);
+            ctx = await startServer(built.app);
+        }
+
+        afterEach(async () => {
+            // Release any handler still parked on a gate, then close the server,
+            // so a failing assertion never leaves the process hanging.
+            built?.controls.releaseAll();
+            if (ctx) {
+                await ctx.close();
+            }
+            built = undefined;
+            ctx = undefined;
+        });
+
+        it('S0 — passes requests through untouched when no idempotency key is present', async () => {
+            await start();
+            const r1 = await ctx.request({ path: '/resource' });
+            const r2 = await ctx.request({ path: '/resource' });
+            assert.equal(r1.status, 200);
+            assert.equal(r2.status, 200);
+            // No key => no idempotency: each request is processed independently.
+            assert.notDeepEqual(r2.body, r1.body);
+            assert.equal(built.controls.count('/resource'), 2);
+        });
+
+        it('S1 — processes a first request normally', async () => {
+            await start();
+            const key = genKey();
+            const r = await ctx.request({ path: '/resource', key });
+            assert.equal(r.status, 200);
+            assert.equal(r.body.callCount, 1);
+            assert.equal(built.controls.count('/resource'), 1);
+        });
+
+        it('S2 — replays the cached response on retry (hit, no re-execution)', async () => {
+            await start();
+            const key = genKey();
+            const r1 = await ctx.request({ path: '/resource', key });
+            const r2 = await ctx.request({ path: '/resource', key });
+            assert.equal(r1.status, 200);
+            assert.equal(r2.status, 200);
+            assert.deepEqual(r2.body, r1.body);
+            assert.equal(built.controls.count('/resource'), 1);
+        });
+
+        it('S3 — returns 409 while a request is still in progress', async () => {
+            await start();
+            const key = genKey();
+            const pA = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 1);
+            const rB = await ctx.request({ path: '/slow', key });
+            assert.equal(rB.status, 409);
+            built.controls.release('/slow#1');
+            const rA = await pA;
+            assert.equal(rA.status, 200);
+            assert.equal(built.controls.count('/slow'), 1);
+        });
+
+        it('S4 — concurrent retries against an in-progress request all get 409', async () => {
+            await start();
+            const key = genKey();
+            const pA = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 1);
+            const retries = await concurrent(4, () =>
+                ctx.request({ path: '/slow', key })
+            );
+            for (const r of retries) {
+                assert.equal(r.status, 'fulfilled');
+                if (r.status === 'fulfilled') {
+                    assert.equal(r.value.status, 409);
+                }
+            }
+            built.controls.release('/slow#1');
+            const rA = await pA;
+            assert.equal(rA.status, 200);
+            assert.equal(built.controls.count('/slow'), 1);
+        });
+
+        it('S5 — takes over an orphaned request after processingTimeout (no hit), then replays the takeover response and guards against the zombie write', async () => {
+            await start({ processingTimeout: 250 });
+            const key = genKey();
+            // A: in-progress, deliberately not released before the lease expires.
+            const pA = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 1);
+            await wait(400); // exceed the 250ms lease
+            // B: takes over -> handler re-executes (instance 2), not a hit.
+            const pB = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 2);
+            built.controls.release('/slow#2');
+            const rB = await pB;
+            assert.equal(rB.status, 200);
+            assert.equal(rB.body.instance, 2);
+            assert.equal(built.controls.count('/slow'), 2);
+            // C: replay of B's response (hit), no third execution.
+            const rC = await ctx.request({ path: '/slow', key });
+            assert.equal(rC.status, 200);
+            assert.deepEqual(rC.body, rB.body);
+            assert.equal(built.controls.count('/slow'), 2);
+            // Zombie guard: releasing A after the takeover must not overwrite B.
+            built.controls.release('/slow#1');
+            await pA.catch(() => undefined);
+            const rC2 = await ctx.request({ path: '/slow', key });
+            assert.deepEqual(rC2.body, rB.body);
+            assert.equal(built.controls.count('/slow'), 2);
+        });
+
+        it('S6 — returns 409 (no takeover) before processingTimeout elapses', async () => {
+            await start({ processingTimeout: 250 });
+            const key = genKey();
+            const pA = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 1);
+            await wait(80); // still within the 250ms lease
+            const rB = await ctx.request({ path: '/slow', key });
+            assert.equal(rB.status, 409);
+            built.controls.release('/slow#1');
+            await pA;
+        });
+
+        it('S7 — cleans up a phantom key when the response bypasses res.send', async () => {
+            await start();
+            const key = genKey();
+            const r1 = await ctx.request({ path: '/raw-end', key });
+            assert.equal(r1.status, 200);
+            assert.equal(r1.body, 'raw');
+            // The finish handler deletes the orphaned resource asynchronously.
+            await waitUntil(() => built.controls.wasDeleted(key));
+            const r2 = await ctx.request({ path: '/raw-end', key });
+            assert.equal(r2.status, 200);
+            assert.equal(built.controls.count('/raw-end'), 2);
+        });
+
+        it('S8 — rejects a reused key with a different intent (417)', async () => {
+            await start();
+            const key = genKey();
+            const r1 = await ctx.request({
+                method: 'POST',
+                path: '/resource',
+                key,
+                body: { a: 1 },
+            });
+            assert.equal(r1.status, 200);
+            const r2 = await ctx.request({
+                method: 'POST',
+                path: '/resource',
+                key,
+                body: { a: 2 },
+            });
+            assert.equal(r2.status, 417);
+        });
+
+        it('S9 — reportError releases the key for reprocessing', async () => {
+            await start();
+            const key = genKey();
+            const r1 = await ctx.request({ path: '/boom', key });
+            assert.equal(r1.status, 500);
+            await waitUntil(() => built.controls.wasDeleted(key));
+            const r2 = await ctx.request({ path: '/resource', key });
+            assert.equal(r2.status, 200);
+            assert.equal(built.controls.count('/resource'), 1);
+        });
+
+        it('S10 — without processingTimeout, an orphaned request stays 409 (v2.0.0 behaviour)', async () => {
+            await start(); // no processingTimeout
+            const key = genKey();
+            const pA = ctx.request({ path: '/slow', key });
+            await waitUntil(() => built.controls.count('/slow') >= 1);
+            await wait(300); // well beyond any would-be timeout
+            const rB = await ctx.request({ path: '/slow', key });
+            assert.equal(rB.status, 409);
+            built.controls.release('/slow#1');
+            await pA;
+        });
+    });
+}

--- a/tests/e2e/harness/server.ts
+++ b/tests/e2e/harness/server.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+import express = require('express');
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import { buildApp } from './buildApp';
+import { req, E2ERequestOptions, E2EResponse } from './client';
+
+export interface RunningServer {
+    server: Server;
+    baseUrl: string;
+    /**
+     * Issue a request against this server and track it as in-flight, so close()
+     * can drain it. Prefer this over the bare `req` helper in tests: a request
+     * left un-awaited (e.g. when an assertion fails before its release) is still
+     * drained on teardown instead of outliving the server.
+     */
+    request(options: E2ERequestOptions): Promise<E2EResponse>;
+    close(): Promise<void>;
+}
+
+/**
+ * Start an Express app on an ephemeral port (0) so multiple servers can run in
+ * parallel without port collisions. Resolves with the bound base URL.
+ */
+export function startServer(app: express.Express): Promise<RunningServer> {
+    return new Promise((resolve) => {
+        const server = app.listen(0, () => {
+            const { port } = server.address() as AddressInfo;
+            const baseUrl = `http://127.0.0.1:${port}`;
+            const inflight = new Set<Promise<unknown>>();
+            resolve({
+                server,
+                baseUrl,
+                request(options: E2ERequestOptions): Promise<E2EResponse> {
+                    const p = req(baseUrl, options);
+                    inflight.add(p);
+                    // Settle handlers (both branches) so an un-awaited request
+                    // never surfaces as an unhandled rejection, and untrack it
+                    // once done. The test still awaits `p` directly when needed.
+                    p.then(
+                        () => inflight.delete(p),
+                        () => inflight.delete(p)
+                    );
+                    return p;
+                },
+                close: () =>
+                    new Promise<void>((done) => {
+                        // Drain in-flight requests first (handlers are released
+                        // in afterEach), so no handler outlives the socket and
+                        // writes to a closed connection.
+                        Promise.allSettled([...inflight]).then(() => {
+                            server.close(() => done());
+                            // Force-close keep-alive sockets: the native fetch
+                            // (undici) pools connections by host:port, and the
+                            // OS often recycles this ephemeral port for the next
+                            // test server. Without this, undici could reuse a
+                            // dead socket pointing at the closed server. Closing
+                            // them here lets undici evict them before reuse.
+                            // (Node >= 18.2; harmless no-op guard on 18.0/18.1.)
+                            if (
+                                typeof server.closeAllConnections === 'function'
+                            ) {
+                                server.closeAllConnections();
+                            }
+                        });
+                    }),
+            });
+        });
+    });
+}
+
+// Standalone mode (`npm run e2e:serve`): exposes the harness for manual probing
+// (curl / REST client), demonstrating the middleware over a real HTTP server.
+if (require.main === module) {
+    const port = Number(process.env.PORT) || 8080;
+    const { app } = buildApp({ processingTimeout: 2000 });
+    app.listen(port, () => {
+        console.log(
+            `express-idempotency e2e harness listening on http://localhost:${port}`
+        );
+    });
+}

--- a/tests/e2e/inmemory.e2e.test.ts
+++ b/tests/e2e/inmemory.e2e.test.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Ville de Montreal. All rights reserved.
+// Licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+import { buildApp } from './harness/buildApp';
+import { runIdempotencySuite } from './harness/scenarios';
+
+describe('InMemoryDataAdapter (default) over real HTTP', () => {
+    runIdempotencySuite((options) => buildApp(options));
+});

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./.temp-e2e",
+        "types": ["node", "mocha"]
+    },
+    "include": ["tests/**/*.ts", "src/**/*.ts"],
+    "exclude": [".temp", ".temp-e2e", "dist", "node_modules"]
+}


### PR DESCRIPTION
Closes #32

## Problem

Between the `create` of an idempotency resource and the fire-and-forget persistence of its response (hooked on `res.send` only), any interruption — process crash/OOM/K8s rollout, an unhandledRejection escaping the route handler, a response emitted through `res.end()`/streaming/`sendFile`, or a silent failure of the hook's update/delete — leaves a resource **without a response**. Every subsequent request with the same key then receives `409 "A previous request is still in progress"` until the data adapter's TTL purges the document (3 days in the production incident that motivated this fix).

## Solution

Two complementary mechanisms, both fully backward compatible (minor release, no change to `IIdempotencyDataAdapter`):

### 1. Processing timeout (lease) — opt-in
- New optional `IdempotencyResource.createdAt` field (`Date | number`), stamped **unconditionally** by the middleware at resource creation. Because the timeout is evaluated at read time, enabling (or tuning) the option later retroactively unblocks orphans already in store.
- New `processingTimeout` option (ms, **disabled by default** — `undefined`/`0`/negative values keep the exact v2.0.0 behaviour). When a request finds an in-progress resource older than the timeout, it takes over: the stale resource is deleted and processing restarts (the `x-hit` marker is cleared so `isHit()` stays truthful). If a concurrent retry wins the race (adapter uniqueness constraint), the loser falls back to the standard 409.
- Intent validation still happens **before** the lease check: an expired lease with a divergent intent returns 417 as today.
- Zombie-write guard: before persisting, the response hook uses `createdAt` as a fencing token (`canStillPersist`). On the nominal path (own lease still valid) this costs **zero** extra adapter reads; only a hook whose own lease has expired refetches and skips persistence if a takeover replaced it. Residual check-then-act window documented: at-least-once semantics apply when the timeout is reached — choose `processingTimeout` well above the worst-case processing duration.
- Adapters that do not persist `createdAt` degrade safely to the current 409 behaviour (feature inert).

### 2. `finish` hook (always on)
- A `res.once('finish')` listener complements the `res.send` hook. When the response bypasses `res.send` (`res.end()`, streaming, `sendFile`), the body cannot be captured, so the resource is deleted (same semantics as a response rejected by the response validator): the route degrades to non-idempotent instead of being poisoned with a permanent 409.
- A `settled` flag set synchronously inside the monkey-patched `send` guarantees no double persistence when `finish` fires after a normal `send`.

### Also fixed
- `InMemoryDataAdapter.update` on a missing key no longer writes a phantom `"-1"` array property (now a no-op, aligned with MongoDB `updateOne` semantics) — this bug was directly reachable through the zombie scenario.

## Tests

- 32 passing (18 existing + 14 new): regression (timeout disabled → 409), within/beyond timeout, takeover end-to-end with replay, legacy adapter without `createdAt`, `createdAt` as epoch/ISO string/garbage, takeover race (create throws → clean 409), expired lease + divergent intent → 417, zombie guard with and without takeover, `res.end` bypass cleanup + retry, finish-after-send no-op, adapter no-op update.
- Time-based cases use `sinon.useFakeTimers({ toFake: ['Date'] })`.
- Coverage on touched files: `idempotencyService.ts` 94.5%, `inMemoryDataAdapter.ts` 100%, `models.ts` 100%.

## End-to-end tests

A reusable e2e suite exercises the full middleware over a **real HTTP server** (Express + native `fetch`, ephemeral port) — not mocks — validating this fix end to end. 11 scenarios (S0–S10): passthrough without key, replay/hit, `409` in-progress, concurrent retries, `processingTimeout` takeover + zombie guard, sub-timeout `409`, phantom-key cleanup (`res.end` bypass), `417` intent mismatch, `reportError`, and the no-timeout regression.

- Harness under `tests/e2e/` (outside `src/`, so excluded from coverage and `dist`), factored as `runIdempotencySuite(makeApp)` so the same guarantees can be replayed against other data adapters (e.g. a future MongoDB adapter).
- Deterministic gates (no sleeps), in-flight draining and a per-request timeout keep the suite non-flaky; standalone mode via `npm run e2e:serve` for manual probing (curl / REST client).
- Runs as a dedicated CircleCI `e2e` job; packaging is gated on `test` + `e2e`. `express` and `cross-env` added as devDependencies. `tests/**` excluded from Codacy, consistent with the existing `**/*.test.ts` / `examples/**` exclusions.
- Documents the Express error-handler contract required to surface the middleware's `409`/`417` (the middleware sets the status then calls `next(err)`).

## Documentation

- README: new "Processing timeout" / « Délai de traitement » sections (EN + FR), updated options snippets, and a "Testing" / « Tests » section covering the unit + e2e layers.
- CHANGELOG: `[Unreleased]` entries (Added / Fixed).

## Follow-ups (separate issues)

1. `express-idempotency-mongo-adapter`: expose `createdAt` in the returned resource + optional short partial TTL index for response-less documents (companion issue).
2. Optional atomic takeover API (`tryTakeover`) on the adapter interface to close the residual race window.
3. Pluggable logger to replace `console.log`/`console.warn`.
