### PR TITLE
ci: run build/lint/test on GitHub Actions, scope CircleCI to publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 # .circleci/config.yml
+#
+# CircleCI is now scoped to npm publishing ONLY. Build, lint and test run on
+# GitHub Actions (see .github/workflows/ci.yml). Publishing stays here because the
+# npm token is a CircleCI secret tied to a maintainer's personal npm account and
+# cannot be moved without an org admin. The publish flow runs only on version tags,
+# so no CircleCI check is posted on branches or pull requests.
 defaults: &defaults
   executor:
     name: node/default
@@ -7,32 +13,22 @@ defaults: &defaults
 version: 2.1
 orbs:
   node: circleci/node@5.1.0
-  coverage-reporter: codacy/coverage-reporter@13.13.7
 jobs:
   build:
     <<: *defaults
     steps:
-      - checkout
+      # Public repo: clone over HTTPS to bypass the CircleCI SSH deploy key.
+      # This flow only runs on version tags (publishing).
+      - run:
+          name: Checkout over HTTPS
+          command: |
+            git clone "https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git" .
+            git checkout -f "${CIRCLE_SHA1}"
       - node/install-packages
       - persist_to_workspace:
           root: /home/circleci
           paths:
             - project/*
-  test:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run: npm test
-      - coverage-reporter/send_report:
-          coverage-reports: "coverage/lcov.info"
-          project-token: ${CODACY_PROJECT_TOKEN}
-  e2e:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci
-      - run: npm run test:e2e
   package:
     <<: *defaults
     steps:
@@ -66,39 +62,22 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - run: 
+      - run:
           name: "Extract release candidate version and update package.json"
-          command: RC_TAG=`echo $CIRCLE_TAG | cut -c 2-` && echo "Extracted version $RC_TAG" && npm version -git-tag-version false $RC_TAG
+          command: RC_TAG=`echo $CIRCLE_TAG | cut -c 2-` && echo "Extracted version $RC_TAG" && npm version --no-git-tag-version $RC_TAG
       - run: npm publish --tag rc --access public
 workflows:
-  main-workflow:
+  publish-on-tag:
     jobs:
       - build:
           filters:
             tags:
               only: /^v\d+\.{1}\d+.{1}\d.*+/
             branches:
-              only: /.*/
-      - test:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^v\d+\.{1}\d+.{1}\d.*+/
-            branches:
-              only: /.*/
-      - e2e:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^v\d+\.{1}\d+.{1}\d.*+/
-            branches:
-              only: /.*/
+              ignore: /.*/
       - package:
           requires:
-            - test
-            - e2e
+            - build
           filters:
             tags:
               only: /^v\d+\.{1}\d+.{1}\d.*+/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+# Build, lint and test on GitHub Actions. npm publishing stays on CircleCI
+# (see .circleci/config.yml) because the npm token is a CircleCI secret tied
+# to a maintainer's personal npm account and cannot be moved without an org admin.
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run prettier
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Test (unit + coverage)
+        run: npm test
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      # Coverage upload runs only on pushes to the upstream repo: secrets are not
+      # exposed to fork PRs, and the token is absent on personal forks. It never
+      # fails the build (continue-on-error) so a missing/expired token stays soft.
+      - name: Upload coverage to Codacy
+        if: ${{ github.event_name == 'push' && github.repository == 'VilledeMontreal/express-idempotency' }}
+        continue-on-error: true
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI: build, lint, unit and e2e tests now run on GitHub Actions (`.github/workflows/ci.yml`); CircleCI is scoped to npm publishing on version tags only. Test coverage is uploaded to Codacy from GitHub Actions.
+
 ## [2.1.0] - 2026-06-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Hooks Husky : `pre-commit` est vide par design ; `pre-push` exécute `npm run pr
 
 ## Release
 
-CircleCI publie sur npm uniquement sur tag git : `vX.Y.Z` → publication normale, `vX.Y.Z-<suffixe>` → publication avec dist-tag `rc`. Les tests tournent sur toutes les branches ; la couverture (lcov) part vers Codacy. Branches : `master` (production) et `develop`.
+**GitHub Actions** (`.github/workflows/ci.yml`) exécute build, lint, prettier, tests unitaires + e2e sur push (toutes branches) et PR ; la couverture (lcov) est uploadée vers Codacy **uniquement sur push vers le repo upstream** (le secret n'est pas exposé aux PR de forks). **CircleCI** (`.circleci/config.yml`) est réduit à la **publication npm sur tag git** : `vX.Y.Z` → publication normale, `vX.Y.Z-<suffixe>` → publication avec dist-tag `rc`. Branches : `master` (production) et `develop`.
 
 ## Tests e2e
 
@@ -37,7 +37,7 @@ Suite de bout en bout dans `tests/e2e/` (**hors `src/`** → exclue de la couver
 - `tests/e2e/harness/` — harness réutilisable : `buildApp(options?)` (app + routes instrumentées + error handler), `startServer(app)` (port 0 + mode standalone, draine les requêtes in-flight au close), `controls` (gates déterministes, compteurs d'exécution, traçage des `delete`), `runIdempotencySuite(makeApp)` rejouable sur n'importe quel data adapter.
 - `tests/e2e/inmemory.e2e.test.ts` — exécute la suite sur l'`InMemoryDataAdapter` par défaut.
 - **Erreurs typées** : le middleware fait `res.status(409|417)` puis `next(err)` avec une erreur exportée portant `statusCode`/`status` (`IdempotencyConflictError` 409, `IdempotencyIntentMismatchError` 417, base `IdempotencyError`) ; Express en dérive le bon code nativement, **même sans error handler**. Le handler de `buildApp` (désactivable via `withErrorHandler: false`) sert de référence pour mettre en forme le corps.
-- Lancé en CI par un job CircleCI dédié `e2e` ; `package` est gaté sur `test` + `e2e`. Le `pre-push` Husky ne lance PAS les e2e (CI-only).
+- Lancé en CI par GitHub Actions (step `E2E tests` du workflow `ci.yml`, après les tests unitaires). Le `pre-push` Husky ne lance PAS les e2e (CI-only).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ Add idempotency to your express route, effortlessly, the way you want it.
 
 #### Production (master)
 
-[![CircleCI](https://circleci.com/gh/VilledeMontreal/express-idempotency/tree/master.svg?style=shield)](https://circleci.com/gh/VilledeMontreal/express-idempotency/tree/master) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/958bd19185f44fcda617a15fb6a72c1d?branch=master)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Grade&branch=master)
+[![CI](https://github.com/VilledeMontreal/express-idempotency/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/VilledeMontreal/express-idempotency/actions/workflows/ci.yml) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/958bd19185f44fcda617a15fb6a72c1d?branch=master)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Grade&branch=master)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/958bd19185f44fcda617a15fb6a72c1d?branch=master)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Coverage&branch=master)
 
 #### Development branch (develop)
 
-[![CircleCI](https://circleci.com/gh/VilledeMontreal/express-idempotency/tree/develop.svg?style=shield)](https://circleci.com/gh/VilledeMontreal/express-idempotency/tree/develop) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/958bd19185f44fcda617a15fb6a72c1d?branch=develop)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Grade&branch=develop)
+[![CI](https://github.com/VilledeMontreal/express-idempotency/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/VilledeMontreal/express-idempotency/actions/workflows/ci.yml) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/958bd19185f44fcda617a15fb6a72c1d?branch=develop)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Grade&branch=develop)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/958bd19185f44fcda617a15fb6a72c1d?branch=develop)](https://www.codacy.com/gh/VilledeMontreal/express-idempotency?utm_source=github.com&utm_medium=referral&utm_content=VilledeMontreal/express-idempotency&utm_campaign=Badge_Coverage&branch=develop)
 
 ([Français](#french-version))


### PR DESCRIPTION
## Contexte

Migration du CI **build / lint / prettier / tests (unitaires + e2e) / coverage** de CircleCI vers **GitHub Actions**. La **publication npm reste sur CircleCI** : le `NPM_TOKEN` est un secret CircleCI lié au compte npm personnel d'un mainteneur et ne peut pas être déplacé sans admin de l'org. Ce changement reprend le pattern déjà en production sur le repo voisin `express-idempotency-mongo-adapter`.

## Changements

- **`.github/workflows/ci.yml` (nouveau)** — job unique `build-test` sur push (toutes branches) + PR, avec `concurrency` cancel-in-progress, Node 22, `npm ci` + cache npm. Steps : lint → prettier → compile → test (unit + coverage) → e2e → upload coverage Codacy.
  - L'upload Codacy ne tourne que `if: push && github.repository == 'VilledeMontreal/express-idempotency'` et en `continue-on-error` : les secrets ne sont pas exposés aux PR de forks, et le step est proprement *skipped* sur les forks (où le token est absent).
- **`.circleci/config.yml`** — réduit au workflow `publish-on-tag` : seuls `build → package → registry-config → deploy / deploy-rc` subsistent, filtrés **tags `v*` uniquement** (`branches: ignore`). Jobs `test`/`e2e` et orb Codacy retirés. Correction au passage du flag cassé du job RC (`-git-tag-version false` → `--no-git-tag-version`).
- **`README.md`** — badge de statut CircleCI remplacé par un badge GitHub Actions (master + develop) ; badges Codacy conservés.
- **`CLAUDE.md`** — sections « Release » et « Tests e2e » mises à jour pour refléter le split GA (CI) / CircleCI (publish).
- **`CHANGELOG.md`** — entrée `[Unreleased] → Changed`.

## ⚠️ Action requise côté mainteneur

Ajouter le secret **`CODACY_PROJECT_TOKEN`** dans *Settings → Secrets and variables → Actions* du repo upstream (même valeur que le secret CircleCI homonyme) pour que la couverture Codacy continue d'être alimentée. Sans lui, le CI ne casse pas (`continue-on-error`), mais le badge Coverage se fige.

## Tests

CI GitHub Actions **verte** sur la branche (job `build-test`) : lint, prettier, compile, **47 tests unitaires**, **14 tests e2e**. Coverage `lcov` générée ; upload Codacy *skipped* sur le fork (comportement attendu, secret upstream-only).

## Revue

Durcie via une boucle de revue adversariale (2 rounds) : correction du flag RC `--no-git-tag-version`, garde `github.repository` sur l'upload Codacy, alignement de la doc `CLAUDE.md`. Verdict final : 0 finding bloquant. La regex de tag du publish et le checkout HTTPS CircleCI sont conservés verbatim (préexistants, éprouvés en prod sur le repo voisin).