### PR TITLE
fix(security): persist only whitelisted request headers (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `requestHeaderWhitelist` option (`string[]`): case-insensitive whitelist of request headers persisted into the `IdempotencyResource`. Defaults to `['content-type']`; pass `[]` to persist none, or add the header names a custom `intentValidator` needs. (issue #36)
+
 ### Changed
 
 - CI: build, lint, unit and e2e tests now run on GitHub Actions (`.github/workflows/ci.yml`); CircleCI is scoped to npm publishing on version tags only. Test coverage is uploaded to Codacy from GitHub Actions.
 
 ### Security
 
+- Request headers are no longer persisted wholesale by data adapters. Previously `convertToIdempotencyRequest` stored the entire `req.headers` object — including `Authorization`, `Cookie` and API keys — into the idempotency resource, exposing those secrets **at rest** for the lifetime of the TTL with a persistent adapter (e.g. the MongoDB adapter). Only a configurable, case-insensitive whitelist is now persisted (default `['content-type']`), so secrets never reach the store. The default intent validator never read headers, so the default configuration keeps the same behaviour. (issue #36)
 - Pin patched versions of two **dev-only transitive** dependencies of the test toolchain via npm `overrides`, clearing the recurring Dependabot security-update failure. Dependabot could not apply the fixes automatically because the only resolvable path would have downgraded `nyc` from `18` to `14` (`security_update_not_possible`). The overrides resolve the advisories at the lockfile level; these packages belong to the test/coverage toolchain only and are **not** part of the published package (`files: ["dist"]`), so runtime consumers were never affected.
   - `@babel/core` (pulled by `nyc → istanbul-lib-instrument`) pinned to `^7.29.6`, fixing GHSA-4x5r-pxfx-6jf8 (arbitrary file read via `sourceMappingURL`, low).
   - `js-yaml` pinned to `^4.2.0`, removing the vulnerable `3.14.2` copy pulled by `nyc → @istanbuljs/load-nyc-config` and fixing GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in merge-key handling, moderate).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ app.post(
         // considered orphaned and can be taken over by a retry.
         // Disabled when absent or <= 0.
         processingTimeout,
+        // Case-insensitive whitelist of request headers persisted at rest.
+        // Default: ['content-type']. Use [] to persist none.
+        requestHeaderWhitelist,
     })
 );
 ```
@@ -181,6 +184,29 @@ app.post(
 - Choose a value at least 2× the worst-case processing duration to avoid false takeovers.
 - Due to the check-then-act nature of the takeover, at-least-once delivery semantics apply when the timeout is reached. If two retries race at expiry, one will win and the other will fall back to a `409`.
 - When a response is sent via `res.end()`, streaming, or `sendFile` (bypassing `res.send`), the middleware cannot capture the body. It automatically deletes the resource so the next retry is reprocessed rather than permanently blocked.
+
+#### Request header filtering
+
+By default the middleware persists **only** the `content-type` request header into the idempotency resource. Every other header — `Authorization`, `Cookie`, API keys — is stripped before the request is handed to the data adapter, so secret-bearing headers are never stored **at rest** for the lifetime of the TTL (previously the whole `req.headers` object was persisted).
+
+Use `requestHeaderWhitelist` to control which headers are kept. Matching is case-insensitive. The list **replaces** the default — it is not merged — so re-include `content-type` explicitly if you still need it.
+
+```javascript
+app.post(
+    '*',
+    idempotency({
+        // Persist no request headers at all:
+        requestHeaderWhitelist: [],
+        // ...or keep the specific headers your custom intent validator needs
+        // (this replaces the default, so add back content-type if required):
+        // requestHeaderWhitelist: ['content-type', 'x-correlation-id'],
+    })
+);
+```
+
+> **Note:** this filters request **headers** only. The request **body** is still persisted as-is, so a secret carried in the body (e.g. a password in a POST payload) is not affected by this option.
+
+**Caveat:** only the **persisted** request is filtered. The intent validator receives the live request untouched, so `isValidIntent(req, idempotencyRequest)` compares the **raw** `req.headers` on one side against the **filtered** `idempotencyRequest.headers` on the other. A custom validator that compares a header must account for that asymmetry (and a header it relies on must be present in the whitelist).
 
 ## Testing
 
@@ -328,6 +354,9 @@ app.post(
         // considérée orpheline et reprise par une nouvelle tentative.
         // Désactivé si absent ou <= 0.
         processingTimeout,
+        // Liste blanche (insensible à la casse) des entêtes de requête persistés
+        // au repos. Défaut : ['content-type']. Utiliser [] pour n'en persister aucun.
+        requestHeaderWhitelist,
     })
 );
 ```
@@ -399,6 +428,29 @@ app.post(
 - Choisir une valeur d'au moins 2× la durée de traitement maximale pour éviter les reprises prématurées.
 - En raison de la nature « vérifier puis agir » de la reprise, une sémantique de livraison « au moins une fois » s'applique lorsque le délai est atteint. Si deux tentatives entrent en concurrence à l'expiration, l'une gagnera et l'autre recevra un `409`.
 - Lorsqu'une réponse est envoyée via `res.end()`, le streaming ou `sendFile` (sans passer par `res.send`), le middleware ne peut pas capturer le corps. Il supprime automatiquement la ressource afin que la prochaine tentative soit retraitée plutôt que bloquée de façon permanente.
+
+#### Filtrage des entêtes de requête
+
+Par défaut, le middleware ne persiste **que** l'entête de requête `content-type` dans la ressource d'idempotence. Tous les autres entêtes — `Authorization`, `Cookie`, clés d'API — sont retirés avant que la requête ne soit remise à l'adapteur de données, de sorte que les entêtes porteurs de secrets ne sont jamais stockés **au repos** pendant toute la durée du TTL (auparavant, l'objet `req.headers` entier était persisté).
+
+Utilisez `requestHeaderWhitelist` pour contrôler les entêtes conservés. La comparaison est insensible à la casse. La liste **remplace** le défaut — elle ne s'y ajoute pas — donc réincluez `content-type` explicitement si vous en avez encore besoin.
+
+```javascript
+app.post(
+    '*',
+    idempotency({
+        // Ne persister aucun entête de requête :
+        requestHeaderWhitelist: [],
+        // ...ou conserver les entêtes dont votre validateur d'intention a besoin
+        // (ceci remplace le défaut, donc rajoutez content-type au besoin) :
+        // requestHeaderWhitelist: ['content-type', 'x-correlation-id'],
+    })
+);
+```
+
+> **Note :** ceci filtre uniquement les **entêtes** de requête. Le **corps** de la requête reste persisté tel quel ; un secret transporté dans le corps (ex. un mot de passe dans un POST) n'est pas affecté par cette option.
+
+**Mise en garde :** seule la requête **persistée** est filtrée. Le validateur d'intention reçoit la requête vivante intacte ; ainsi `isValidIntent(req, idempotencyRequest)` compare les `req.headers` **bruts** d'un côté aux `idempotencyRequest.headers` **filtrés** de l'autre. Un validateur personnalisé qui compare un entête doit tenir compte de cette asymétrie (et l'entête dont il dépend doit figurer dans la liste blanche).
 
 ## Tests
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -151,4 +151,19 @@ export interface IdempotencyOptions {
      * delivery semantics apply when the timeout is reached.
      */
     processingTimeout?: number;
+    /**
+     * Case-insensitive whitelist of request header names persisted into the
+     * `IdempotencyResource`. Any header not in this list is stripped before the
+     * request is handed to the data adapter, so secrets such as `Authorization`,
+     * `Cookie` or API keys are never stored at rest for the lifetime of the TTL.
+     * Default: `['content-type']`. Pass `[]` to persist no headers, or add the
+     * header names a custom `intentValidator` needs to compare. A provided list
+     * replaces the default entirely (it is not merged), so re-include
+     * `content-type` explicitly if you still need it.
+     *
+     * Note: the persisted headers are filtered, but the live `req.headers` passed
+     * to `intentValidator.isValidIntent(req, idempotencyRequest)` are not — a
+     * custom validator comparing a header must account for that asymmetry.
+     */
+    requestHeaderWhitelist?: string[];
 }

--- a/src/services/idempotencyService.test.ts
+++ b/src/services/idempotencyService.test.ts
@@ -1060,3 +1060,102 @@ describe('Idempotency service — error typing, async guard & hit spoofing (#33/
         assert.isTrue(next.calledOnce);
     });
 });
+
+// #36 — request headers (Authorization, Cookie, API keys) must not be persisted
+// at rest. Only a configurable, case-insensitive whitelist is stored.
+describe('Idempotency service — request header filtering', () => {
+    let dataAdapter: InMemoryDataAdapter = null;
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    function makeService(
+        requestHeaderWhitelist?: string[]
+    ): IdempotencyService {
+        dataAdapter = new InMemoryDataAdapter();
+        return new IdempotencyService({
+            idempotencyKeyHeader: 'idempotency-key',
+            intentValidator: new DefaultIntentValidator(),
+            dataAdapter,
+            responseValidator: new SuccessfulResponseValidator(),
+            requestHeaderWhitelist,
+        });
+    }
+
+    // Persist a fresh resource for `key` carrying the given headers and return
+    // the stored request headers. `create` runs synchronously before next(), so
+    // the resource is available as soon as the middleware resolves.
+    async function persistedHeaders(
+        svc: IdempotencyService,
+        key: string,
+        headers: Record<string, string>
+    ): Promise<any> {
+        const req = httpMocks.createRequest({
+            url: 'https://something/path',
+            method: 'POST',
+            headers: { 'idempotency-key': key, ...headers },
+        });
+        await svc.provideMiddlewareFunction(
+            req,
+            httpMocks.createResponse(),
+            sinon.spy()
+        );
+        const stored = await dataAdapter.findByIdempotencyKey(key);
+        return stored.request.headers;
+    }
+
+    it('persists only the default-whitelisted header (content-type) and drops secrets', async () => {
+        const svc = makeService();
+        const headers = await persistedHeaders(svc, 'key-default', {
+            authorization: 'Bearer super-secret',
+            cookie: 'session=abc',
+            'content-type': 'application/json',
+        });
+
+        assert.deepEqual(headers, { 'content-type': 'application/json' });
+        assert.notProperty(headers, 'authorization');
+        assert.notProperty(headers, 'cookie');
+        // The idempotency key header itself is not whitelisted, so it is dropped
+        // too (it is never read from the persisted request).
+        assert.notProperty(headers, 'idempotency-key');
+    });
+
+    it('honours a custom whitelist with case-insensitive matching', async () => {
+        const svc = makeService(['Authorization', 'X-Correlation-ID']);
+        const headers = await persistedHeaders(svc, 'key-custom', {
+            authorization: 'Bearer token',
+            'x-correlation-id': 'cid-123',
+            'content-type': 'application/json',
+            cookie: 'session=abc',
+        });
+
+        assert.deepEqual(headers, {
+            authorization: 'Bearer token',
+            'x-correlation-id': 'cid-123',
+        });
+        assert.notProperty(headers, 'content-type');
+        assert.notProperty(headers, 'cookie');
+    });
+
+    it('persists no headers when the whitelist is empty', async () => {
+        const svc = makeService([]);
+        const headers = await persistedHeaders(svc, 'key-empty', {
+            authorization: 'Bearer token',
+            'content-type': 'application/json',
+        });
+
+        assert.deepEqual(headers, {});
+    });
+
+    it('keeps a whitelisted header even when its value is falsy (filters on keys, not values)', async () => {
+        const svc = makeService(['x-empty']);
+        const headers = await persistedHeaders(svc, 'key-falsy', {
+            'x-empty': '',
+            authorization: 'Bearer token',
+        });
+
+        assert.deepEqual(headers, { 'x-empty': '' });
+        assert.notProperty(headers, 'authorization');
+    });
+});

--- a/src/services/idempotencyService.ts
+++ b/src/services/idempotencyService.ts
@@ -21,6 +21,10 @@ import {
 
 // Default values
 const IDEMPOTENCY_KEY_HEADER = 'idempotency-key';
+// Request headers persisted by default. Keeps the non-sensitive content-type
+// (useful to some custom intent validators) while dropping Authorization,
+// Cookie, API keys, etc. so they are never stored at rest.
+const DEFAULT_REQUEST_HEADER_WHITELIST = ['content-type'];
 
 /**
  * This class represent the idempotency service.
@@ -51,6 +55,13 @@ export class IdempotencyService {
         const intentValidator =
             options.intentValidator ?? new DefaultIntentValidator();
 
+        // Normalise the request-header whitelist to lower case so matching is
+        // case-insensitive regardless of how the caller spelled the names. A `??`
+        // (not `||`) preserves an explicit empty array meaning "persist none".
+        const requestHeaderWhitelist = (
+            options.requestHeaderWhitelist ?? DEFAULT_REQUEST_HEADER_WHITELIST
+        ).map((name) => name.toLowerCase());
+
         // Normalise processingTimeout: absent/0/negative/non-finite = feature disabled (0).
         const processingTimeout =
             typeof options.processingTimeout === 'number' &&
@@ -66,6 +77,7 @@ export class IdempotencyService {
             responseValidator,
             intentValidator,
             processingTimeout,
+            requestHeaderWhitelist,
         };
     }
 
@@ -216,11 +228,33 @@ export class IdempotencyService {
     ): IdempotencyRequest {
         return {
             body: req.body,
-            headers: req.headers,
+            headers: this.filterRequestHeaders(req.headers),
             method: req.method,
             query: req.query,
             url: req.url,
         };
+    }
+
+    /**
+     * Keep only the whitelisted request headers (case-insensitive) so secrets
+     * (Authorization, Cookie, API keys) are never persisted at rest by the data
+     * adapter. Node lower-cases incoming header names and the whitelist is
+     * lower-cased at construction time, so the comparison is case-insensitive.
+     * Mirrors the response-header whitelist applied in `buildIdempotencyResponse`.
+     * @param headers Raw request headers
+     */
+    private filterRequestHeaders(headers: any): any {
+        const whitelist = this._options.requestHeaderWhitelist;
+        if (!headers) {
+            return {};
+        }
+        // Build from entries (rather than a keyed assignment) so we avoid a
+        // dynamic object-injection sink on a computed key.
+        return Object.fromEntries(
+            Object.entries(headers).filter(([name]) =>
+                whitelist.includes(name.toLowerCase())
+            )
+        );
     }
 
     /**

--- a/tests/e2e/inmemory.e2e.test.ts
+++ b/tests/e2e/inmemory.e2e.test.ts
@@ -8,6 +8,7 @@ import { makeControls } from './harness/controls';
 import { startServer } from './harness/server';
 import { genKey, waitUntil } from './harness/helpers';
 import { runIdempotencySuite } from './harness/scenarios';
+import { InMemoryDataAdapter } from '../../src/defaults/inMemoryDataAdapter';
 
 describe('InMemoryDataAdapter (default) over real HTTP', () => {
     runIdempotencySuite((options) => buildApp(options));
@@ -28,6 +29,72 @@ describe('InMemoryDataAdapter — error status without a custom error handler (#
             built.controls.release('/slow#1');
             const rA = await pA;
             assert.equal(rA.status, 200);
+        } finally {
+            built.controls.releaseAll();
+            await ctx.close();
+        }
+    });
+});
+
+describe('Request header filtering at rest over real HTTP (#36)', () => {
+    // Inspect what the data adapter actually stored, proving secrets never reach
+    // persistence. A reference to the inner adapter is kept so the persisted
+    // resource can be read back through the public findByIdempotencyKey API.
+    it('persists only the default-whitelisted content-type, never Authorization/Cookie', async () => {
+        const adapter = new InMemoryDataAdapter();
+        const built = buildApp({ dataAdapter: adapter });
+        const ctx = await startServer(built.app);
+        try {
+            const key = genKey();
+            const r = await ctx.request({
+                path: '/resource',
+                method: 'POST',
+                key,
+                body: { hello: 'world' }, // sets content-type: application/json
+                headers: {
+                    authorization: 'Bearer e2e-super-secret',
+                    cookie: 'session=should-not-persist',
+                },
+            });
+            assert.equal(r.status, 200);
+
+            const stored = await adapter.findByIdempotencyKey(key);
+            assert.deepEqual(stored.request.headers, {
+                'content-type': 'application/json',
+            });
+            assert.notProperty(stored.request.headers, 'authorization');
+            assert.notProperty(stored.request.headers, 'cookie');
+        } finally {
+            built.controls.releaseAll();
+            await ctx.close();
+        }
+    });
+
+    it('persists exactly the configured custom whitelist (case-insensitive)', async () => {
+        const adapter = new InMemoryDataAdapter();
+        const built = buildApp({
+            dataAdapter: adapter,
+            requestHeaderWhitelist: ['X-Keep'],
+        });
+        const ctx = await startServer(built.app);
+        try {
+            const key = genKey();
+            const r = await ctx.request({
+                path: '/resource',
+                method: 'POST',
+                key,
+                headers: {
+                    authorization: 'Bearer e2e-super-secret',
+                    'x-keep': 'kept-value',
+                },
+            });
+            assert.equal(r.status, 200);
+
+            const stored = await adapter.findByIdempotencyKey(key);
+            assert.deepEqual(stored.request.headers, {
+                'x-keep': 'kept-value',
+            });
+            assert.notProperty(stored.request.headers, 'authorization');
         } finally {
             built.controls.releaseAll();
             await ctx.close();


### PR DESCRIPTION
## Problem

`convertToIdempotencyRequest` stored the entire `req.headers` object — including `Authorization`, `Cookie` and API keys — into the persisted `IdempotencyResource`. With a persistent data adapter (e.g. `express-idempotency-mongo-adapter`), those secrets are written **at rest** for the whole TTL lifetime. The default intent validator never reads headers, so for the default configuration this data is stored without ever being read.

Fixes #36.

## Fix

Persist only a configurable, **case-insensitive** whitelist of request headers via a new `requestHeaderWhitelist` option:

- Default `['content-type']` — secrets such as `Authorization` / `Cookie` are stripped before the request reaches the data adapter.
- Pass `[]` to persist no headers, or list the header names a custom `intentValidator` needs. The list **replaces** the default (not merged).
- Mirrors the existing response-header whitelist already applied in `buildIdempotencyResponse`.

## Backward compatibility

- The `DefaultIntentValidator` never read headers, so the **default configuration keeps the same behaviour**.
- The `IIdempotencyDataAdapter` interface is **unchanged** — no breaking change for external adapters; only the persisted shape contains fewer headers.

## Tests & docs

- Unit tests: default whitelist drops secrets / keeps `content-type`, custom whitelist (case-insensitive), empty whitelist, falsy-value header kept.
- E2E (real HTTP): asserts the data adapter stored only the whitelisted header and never `Authorization`/`Cookie`.
- README updated in **both** English and French sections; `CHANGELOG.md` updated under `[Unreleased]` (`Added` + `Security`).

All unit (51) + e2e (16) tests, ESLint and Prettier pass.