### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,7 @@ All notable changes to this library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- `requestHeaderWhitelist` option (`string[]`): case-insensitive whitelist of request headers persisted into the `IdempotencyResource`. Defaults to `['content-type']`; pass `[]` to persist none, or add the header names a custom `intentValidator` needs. (issue #36)
-
-### Changed
-
-- CI: build, lint, unit and e2e tests now run on GitHub Actions (`.github/workflows/ci.yml`); CircleCI is scoped to npm publishing on version tags only. Test coverage is uploaded to Codacy from GitHub Actions.
-
-### Security
-
-- Request headers are no longer persisted wholesale by data adapters. Previously `convertToIdempotencyRequest` stored the entire `req.headers` object — including `Authorization`, `Cookie` and API keys — into the idempotency resource, exposing those secrets **at rest** for the lifetime of the TTL with a persistent adapter (e.g. the MongoDB adapter). Only a configurable, case-insensitive whitelist is now persisted (default `['content-type']`), so secrets never reach the store. The default intent validator never read headers, so the default configuration keeps the same behaviour. (issue #36)
-- Pin patched versions of two **dev-only transitive** dependencies of the test toolchain via npm `overrides`, clearing the recurring Dependabot security-update failure. Dependabot could not apply the fixes automatically because the only resolvable path would have downgraded `nyc` from `18` to `14` (`security_update_not_possible`). The overrides resolve the advisories at the lockfile level; these packages belong to the test/coverage toolchain only and are **not** part of the published package (`files: ["dist"]`), so runtime consumers were never affected.
-  - `@babel/core` (pulled by `nyc → istanbul-lib-instrument`) pinned to `^7.29.6`, fixing GHSA-4x5r-pxfx-6jf8 (arbitrary file read via `sourceMappingURL`, low).
-  - `js-yaml` pinned to `^4.2.0`, removing the vulnerable `3.14.2` copy pulled by `nyc → @istanbuljs/load-nyc-config` and fixing GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in merge-key handling, moderate).
-
-## [2.1.0] - 2026-06-19
+## [2.1.0] - 2026-06-25
 
 ### Added
 
@@ -30,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `processingTimeout` option (milliseconds): lease mechanism that allows a retry to take over processing of an in-progress resource after the timeout elapses, preventing permanent `409` locks caused by orphaned requests (crash, OOM, rollout). Opt-in; disabled when absent or `<= 0`. Requires the data adapter to persist and return `IdempotencyResource.createdAt`. (issue #32)
 - `IdempotencyResource.createdAt` field (`Date | number`, optional): timestamp stamped unconditionally by the middleware at resource creation. Used by the `processingTimeout` lease mechanism; absent value degrades safely to the v2.0.0 behaviour.
 - End-to-end test suite (`npm run test:e2e`) exercising the middleware over a real HTTP server (Express + native `fetch`): replay/hit, `409` in-progress conflict, concurrent retries, `processingTimeout` takeover, zombie-write guard, phantom-key cleanup (`res.end` bypass), intent mismatch (`417`) and `reportError`. Factored as `runIdempotencySuite` for reuse across data adapters, runnable standalone via `npm run e2e:serve`, and wired as a dedicated CI job.
+- `requestHeaderWhitelist` option (`string[]`): case-insensitive whitelist of request headers persisted into the `IdempotencyResource`. Defaults to `['content-type']`; pass `[]` to persist none, or add the header names a custom `intentValidator` needs. (issue #36)
+
+### Changed
+
+- CI: build, lint, unit and e2e tests now run on GitHub Actions (`.github/workflows/ci.yml`); CircleCI is scoped to npm publishing on version tags only. Test coverage is uploaded to Codacy from GitHub Actions.
 
 ### Fixed
 
@@ -39,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The idempotency hit marker is no longer derived from a client-controlled `x-hit` request header (spoofable — a forged value made route handlers skip their response, a denial-of-service primitive). It is now tracked server-side via a `WeakSet` keyed on the request object; the public `isHit(req)` API is unchanged. (issue #35)
 - Resources left in-progress when the response bypasses `res.send` (e.g. `res.end()`, streaming, `sendFile`) are now automatically deleted on the `finish` event, allowing the next retry to be reprocessed instead of receiving a permanent `409`.
 - `InMemoryDataAdapter.update` no longer creates a phantom `"-1"` property on the internal array when called with an unknown key; it is now a no-op, aligned with MongoDB `updateOne` semantics.
+
+### Security
+
+- Request headers are no longer persisted wholesale by data adapters. Previously `convertToIdempotencyRequest` stored the entire `req.headers` object — including `Authorization`, `Cookie` and API keys — into the idempotency resource, exposing those secrets **at rest** for the lifetime of the TTL with a persistent adapter (e.g. the MongoDB adapter). Only a configurable, case-insensitive whitelist is now persisted (default `['content-type']`), so secrets never reach the store. The default intent validator never read headers, so the default configuration keeps the same behaviour. (issue #36)
+- Pin patched versions of two **dev-only transitive** dependencies of the test toolchain via npm `overrides`, clearing the recurring Dependabot security-update failure. Dependabot could not apply the fixes automatically because the only resolvable path would have downgraded `nyc` from `18` to `14` (`security_update_not_possible`). The overrides resolve the advisories at the lockfile level; these packages belong to the test/coverage toolchain only and are **not** part of the published package (`files: ["dist"]`), so runtime consumers were never affected.
+  - `@babel/core` (pulled by `nyc → istanbul-lib-instrument`) pinned to `^7.29.6`, fixing GHSA-4x5r-pxfx-6jf8 (arbitrary file read via `sourceMappingURL`, low).
+  - `js-yaml` pinned to `^4.2.0`, removing the vulnerable `3.14.2` copy pulled by `nyc → @istanbuljs/load-nyc-config` and fixing GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in merge-key handling, moderate).
 
 ## [2.0.0] - 2025-11-05
 
@@ -187,5 +182,6 @@ For detailed migration instructions from 1.0.x to 2.0.0, see [MIGRATION_PLAN.md]
 3. **Install**: `npm install express-idempotency@2.0.0`
 4. **Test**: Run your tests to ensure type compatibility
 
+[2.1.0]: https://github.com/VilledeMontreal/express-idempotency/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/VilledeMontreal/express-idempotency/compare/v1.0.5...v2.0.0
 [1.0.5]: https://github.com/VilledeMontreal/express-idempotency/releases/tag/v1.0.5


### PR DESCRIPTION
## Release 2.1.0

Finalizes the `2.1.0` release notes so the version can be tagged and published. **No code change** — `package.json` and `package-lock.json` are already at `2.1.0`.

### Why
`2.1.0` was prepared (version bumped, CHANGELOG section dated) but **never tagged or published** — npm `latest` is still `2.0.0` and there is no `v2.1.0` tag. Meanwhile more changes landed in `[Unreleased]`. This PR folds `[Unreleased]` into a single dated `2.1.0` entry so the release captures everything since `2.0.0`.

### CHANGELOG changes
- `[Unreleased]` → merged into `## [2.1.0] - 2026-06-25`.
- Sections ordered per Keep a Changelog: **Added** (incl. `requestHeaderWhitelist`, #36), **Changed** (CI → GitHub Actions, #45), **Fixed**, **Security** (request-header whitelist #36 + dev-only dep overrides #46).
- Added the `v2.0.0...v2.1.0` comparison link.

### Publish (maintainer, after merge)
Per `.circleci/config.yml`, publishing is triggered by a git tag:

```bash
git tag v2.1.0 <merge-commit>   # on master
git push upstream v2.1.0        # CircleCI publishes to npm (latest)
```

`npm run compile` was verified to emit a clean flat `dist/` with the new `requestHeaderWhitelist?: string[]` in `dist/models/models.d.ts`.