### PR TITLE
docs: document master branch protection ruleset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Sept fichiers source dans `src/`, tout est ré-exporté par `src/index.ts` (barr
 
 - **DCO obligatoire** : toujours committer avec `git commit -s` (`Signed-off-by` correspondant à l'auteur). Le check DCO des PRs échoue sinon ; rattrapage : `git commit --amend -s --no-edit` puis force-push.
 - **Workflow fork** : `origin` = fork, `upstream` = `VilledeMontreal`. Brancher depuis `upstream/master`, pousser la branche sur le fork, ouvrir la PR vers `master` d'upstream.
+- **Branch protection `master`** : un ruleset GitHub protège `master` — PR obligatoire (0 approbation requise), status check `build-test` (CI GitHub Actions) requis, pas de force-push ni de suppression de branche. Le rôle *Repository admin* peut contourner (bypass toujours actif, à réserver aux urgences). Les push directs sur `master` sont bloqués ; tout passe par une PR avec CI verte.
 
 ## Conventions du repo
 


### PR DESCRIPTION
## Contexte
Un ruleset de protection de branche a été mis en place sur `master` (PR obligatoire, status check `build-test`, pas de force-push ni de suppression, bypass *Repository admin*). Ce changement documente cette protection dans le `CLAUDE.md` afin que le workflow attendu soit explicite pour les contributeurs et l'outillage.

## Changements
- `CLAUDE.md`, section « Git et PRs » : ajout d'une puce décrivant le ruleset de protection de `master`.

## Tests
Changement documentaire uniquement (aucun code touché). CI verte : build, lint, prettier, tests unitaires + e2e ✓.

## Revue
Audit adversarial (critic) : exactitude factuelle vérifiée contre la configuration réelle du ruleset, cohérence de style avec le reste du fichier, aucune fuite d'information. Verdict **PASS** (0 blocking, 0 major) ; un point mineur de formulation (« bypass pour les urgences » → précision que le bypass admin est inconditionnel) a été corrigé.